### PR TITLE
Add config option to specify additional headers for serve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 - Added `data-target-path` to `copy-dir`.
 - Allow processing `<script>` tags with the asset pipeline.
 - Added `data-loader-shim` to workers to create shim script.
+- Added `headers` config option for `trunk serve`.
 ### changed
 - Updated gloo-worker example to use gloo-worker crate v2.1.
 - Our website (trunkrs.dev) now only updates on new releases.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ tokio = { version = "1", default-features = false, features = ["full"] }
 tokio-stream = { version = "0.1", default-features = false, features = ["fs", "sync"] }
 tokio-tungstenite = "0.17"
 toml = "0.5"
-tower-http = { version = "0.3", features = ["fs", "trace"] }
+tower-http = { version = "0.3", features = ["fs", "trace", "set-header"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 which = "4"

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -27,6 +27,8 @@ port = 8080
 open = false
 # Disable auto-reload of the web app.
 no_autoreload = false
+# Additional headers set for responses.
+#headers = { "test-header" = "header value", "test-header2" = "header value 2" }
 
 [clean]
 # The output dir for all final assets.

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -127,6 +127,10 @@ pub struct ConfigOptsServe {
     #[clap(long = "no-autoreload")]
     #[serde(default)]
     pub no_autoreload: bool,
+    /// Additional headers to send in responses [default: none]
+    #[clap(skip)]
+    #[serde(default)]
+    pub headers: HashMap<String, String>,
 }
 
 /// Config options for the serve system.
@@ -336,6 +340,7 @@ impl ConfigOpts {
             proxy_insecure: cli.proxy_insecure,
             proxy_ws: cli.proxy_ws,
             no_autoreload: cli.no_autoreload,
+            headers: cli.headers,
         };
         let cfg = ConfigOpts {
             build: None,
@@ -510,6 +515,7 @@ impl ConfigOpts {
                 if l.open {
                     g.open = true;
                 }
+                g.headers.extend(l.headers);
                 Some(g)
             }
         };

--- a/src/config/rt.rs
+++ b/src/config/rt.rs
@@ -218,6 +218,8 @@ pub struct RtcServe {
     pub proxies: Option<Vec<ConfigOptsProxy>>,
     /// Whether to disable auto-reload of the web page when a build completes.
     pub no_autoreload: bool,
+    /// Additional headers to include in responses.
+    pub headers: HashMap<String, String>,
 }
 
 impl RtcServe {
@@ -247,6 +249,7 @@ impl RtcServe {
             proxy_ws: opts.proxy_ws,
             proxies,
             no_autoreload: opts.no_autoreload,
+            headers: opts.headers,
         })
     }
 }


### PR DESCRIPTION
I'm using webworkers (based on #285) and want to use `SharedArrayBuffer`. That requires setting the headers `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp`. To allow this configuration during development with `trunk serve`, I added a config option which allows specifying any number of header-value pairs, which are included in responses.

Fix #414

**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [ ] Updated `site` content with pertinent info (may not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
