### PR TITLE
Download aarch64 wasm bindgen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 - Added `data-loader-shim` to workers to create shim script.
 - Added tailwindcss support via `rel="tailwind-css"`.
 - Added support for `svg` files when using `rel="inline"`
-- Print all acessible addresses if `0.0.0.0` is used.
+- Print all accessible addresses if `0.0.0.0` is used.
+- Download aarch64 wasm-bindgen on MacOS and Linux.
 
 ### changed
 - Updated gloo-worker example to use gloo-worker crate v2.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,14 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 - Updated internal http stack to axum v0.6.0.
 - Updated CLI argument parser to clap v0.4.
 - Reduce error to warning when processing a project without Cargo.toml and no `<link rel="rust"/>` (fixes #487)
+- Add wasm-bindgen URLs for all supported architectures
 
 ### fixed
 - Nested WS proxies - if `backend=ws://localhost:8000/ws` is set, queries for `ws://localhost:8080/ws/entityX` will be linked with `ws://localhost:8000/ws/entityX`
 - Updated all dependencies in both Trunk and its examples, to fix currently open security advisories for old dependencies.
+- Features passed to trunk build are now passed to cargo build (unless overridden by attributes in the HTML file)
 - Fix [trunk/issues/330](https://github.com/thedodd/trunk/issues/330), to properly handle proxy endpoint with and without a slash at the end.
+- Fix [trunk/issues/475](https://github.com/thedodd/trunk/issues/475) indeterminate trunk behaviour when the project defines several binary crates and index.html has no `<link rel="rust" data-bin=...>`
 
 ## 0.16.0
 ### added

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -38,7 +38,7 @@ cargo = false
 # Default dart-sass version to download.
 sass = "1.54.9"
 # Default wasm-bindgen version to download.
-wasm_bindgen = "0.2.83"
+wasm_bindgen = "0.2.84"
 # Default wasm-opt version to download.
 wasm_opt = "version_110"
 

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -18,13 +18,11 @@ wget -qO- https://github.com/thedodd/trunk/releases/download/${VERSION}/trunk-x8
 
 # Install via cargo.
 cargo install --locked trunk
-# Until wasm-bindgen has pre-built binaries for Apple M1, M1 users will
-# need to install wasm-bindgen manually.
-cargo install --locked wasm-bindgen-cli
 ```
 <small>Release binaries can be found on the [Github releases page](https://github.com/thedodd/trunk/releases).</small>
 
 Any additional tools like `wasm-bindgen` and `wasm-opt` are automatically downloaded and managed by trunk. Therefore, no further steps required 🎉.
+Note: On Linux arm64, you will need to build `wasm-opt` manually if you need it. See [this issue](https://github.com/WebAssembly/binaryen/issues/5337).
 
 ## App Setup
 Get setup with your favorite `wasm-bindgen` based framework. [Yew](https://github.com/yewstack/yew) & [Seed](https://github.com/seed-rs/seed) are the most popular options today, but there are others. Trunk will work with any `wasm-bindgen` based framework. The easiest way to ensure that your application launches properly is to [setup your app as an executable](https://doc.rust-lang.org/cargo/guide/project-layout.html) with a standard `main` function:

--- a/src/pipelines/rust.rs
+++ b/src/pipelines/rust.rs
@@ -154,11 +154,14 @@ impl RustApp {
 
         let cargo_features = if data_all_features {
             Features::All
-        } else {
+        } else if data_no_default_features || data_features.is_some() {
             Features::Custom {
                 features: data_features,
                 no_default_features: data_no_default_features,
             }
+        } else {
+            // The features have not been overridden in the attributes so use the features passed to cargo
+            cfg.cargo_features.clone()
         };
 
         Ok(Self {
@@ -297,20 +300,38 @@ impl RustApp {
 
         // Stream over cargo messages to find the artifacts we are interested in.
         let reader = std::io::BufReader::new(artifacts_out.stdout.as_slice());
-        let artifact = cargo_metadata::Message::parse_stream(reader)
-            .filter_map(|msg| if let Ok(msg) = msg { Some(msg) } else { None })
-            .fold(Ok(None), |acc, msg| match msg {
-                cargo_metadata::Message::CompilerArtifact(art)
-                    if art.package_id == self.manifest.package.id =>
-                {
-                    Ok(Some(art))
-                }
-                cargo_metadata::Message::BuildFinished(finished) if !finished.success => {
-                    Err(anyhow!("error while fetching cargo artifact info"))
-                }
-                _ => acc,
-            })?
-            .context("cargo artifacts not found for target crate")?;
+        let mut bin_artifacts: Vec<cargo_metadata::Artifact> =
+            cargo_metadata::Message::parse_stream(reader)
+                .filter_map(|msg| msg.ok())
+                .filter_map(|msg| match msg {
+                    cargo_metadata::Message::CompilerArtifact(art)
+                        if art.package_id == self.manifest.package.id
+                            && art.target.kind.iter().any(|k| k == "bin") =>
+                    {
+                        Some(Ok(art))
+                    }
+                    cargo_metadata::Message::BuildFinished(finished) if !finished.success => {
+                        Some(Err(anyhow!("error while fetching cargo artifact info")))
+                    }
+                    _ => None,
+                })
+                .collect::<Result<_>>()?;
+        // If there is already a `link data-trunk rel=rust` in index.html
+        // then the --bin flag was passed to the cargo command
+        // and it has built just a single binary
+        if bin_artifacts.len() > 1 {
+            bail!(
+                "found more than one binary crate: {bin_names:?}, consider adding `<link \
+                 data-trunk rel=\"rust\" data-bin={{bin}} />` to the index.html",
+                bin_names = bin_artifacts
+                    .iter()
+                    .map(|a| &a.target.name)
+                    .collect::<Vec<_>>()
+            )
+        }
+        let Some(artifact) = bin_artifacts.pop() else {
+            bail!("cargo artifacts not found for target crate")
+        };
 
         // Get a handle to the WASM output file.
         let wasm = artifact

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -88,7 +88,7 @@ impl Application {
         match self {
             Self::Sass => "1.54.9",
             Self::TailwindCss => "3.2.7",
-            Self::WasmBindgen => "0.2.83",
+            Self::WasmBindgen => "0.2.84",
             Self::WasmOpt => "version_110",
         }
     }
@@ -129,12 +129,12 @@ impl Application {
             },
 
             Self::WasmBindgen => format!(
-                "https://github.com/rustwasm/wasm-bindgen/releases/download/{version}/wasm-bindgen-{version}-x86_64-{os}.tar.gz",
-                os = match target_os {
-                "windows" => "pc-windows-msvc",
-                "macos" => "apple-darwin",
-                "linux" => "unknown-linux-musl",
-                _ => unreachable!(),
+                "https://github.com/rustwasm/wasm-bindgen/releases/download/{version}/wasm-bindgen-{version}-{platform}.tar.gz",
+                platform = match (target_os, target_arch) {
+                    ("windows", "x86_64") => format!("{}-pc-windows-msvc", target_arch),
+                    ("macos", "x86_64" | "aarch64") => format!("{}-apple-darwin", target_arch),
+                    ("linux", "x86_64" | "aarch64") => format!("{}-unknown-linux-musl", target_arch),
+                    _ => unreachable!(),
               }),
 
             Self::WasmOpt => match (target_os, target_arch) {


### PR DESCRIPTION
Relates to #529, adds automatic downloading for aarch64 wasm bindgen for Linux and MacOS.

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [x] Updated README.md with pertinent info (may not always apply).
- [x] Updated `site` content with pertinent info (may not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
