### PR TITLE
Allow cdylib targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 ## Unreleased
 ### changed
 - Remove HTML glob in tailwind.config.js
+- Add check to see if artifact is a cdylib target (fixes #575)
 
 ## 0.17.4
 ### added

--- a/src/pipelines/rust.rs
+++ b/src/pipelines/rust.rs
@@ -307,7 +307,8 @@ impl RustApp {
                 .filter_map(|msg| match msg {
                     cargo_metadata::Message::CompilerArtifact(art)
                         if art.package_id == self.manifest.package.id
-                            && art.target.kind.iter().any(|k| k == "bin") =>
+                            && (art.target.kind.contains(&"bin".to_string())
+                                || art.target.kind.contains(&"cdylib".to_string())) =>
                     {
                         Some(Ok(art))
                     }


### PR DESCRIPTION
Adds a check to see if artifact is a cdylib target to fix regression in #476.  Fixes #575 

**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [ ] Updated `site` content with pertinent info (may not always apply).
- [ ] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.