### PR TITLE
Add polling mode in case FS changes don't get detected

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2643,7 +2643,7 @@ dependencies = [
 
 [[package]]
 name = "trunk"
-version = "0.17.3"
+version = "0.17.5"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,6 +964,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2659,6 +2675,8 @@ dependencies = [
  "flate2",
  "fs_extra",
  "futures-util",
+ "humantime",
+ "humantime-serde",
  "local-ip-address",
  "nipper",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ fs_extra = "1"
 futures-util = { version = "0.3", default-features = false, features = [
   "sink",
 ] }
+humantime = "2"
+humantime-serde = "1"
 local-ip-address = "0.5.1"
 nipper = "0.1"
 notify = "6"

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -3,10 +3,12 @@ use std::net::IpAddr;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use axum::http::Uri;
 use clap::Args;
+use humantime_serde::re::humantime;
 use serde::{Deserialize, Deserializer};
 
 use crate::common::parse_public_url;
@@ -88,6 +90,26 @@ pub struct ConfigOptsBuild {
     pub pattern_params: Option<HashMap<String, String>>,
 }
 
+#[derive(Clone, Debug)]
+pub struct ConfigDuration(pub Duration);
+
+impl<'de> Deserialize<'de> for ConfigDuration {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Self(humantime_serde::deserialize(deserializer)?))
+    }
+}
+
+impl FromStr for ConfigDuration {
+    type Err = humantime::DurationError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        Ok(Self(humantime::Duration::from_str(s)?.into()))
+    }
+}
+
 /// Config options for the watch system.
 #[derive(Clone, Debug, Default, Deserialize, Args)]
 pub struct ConfigOptsWatch {
@@ -101,6 +123,9 @@ pub struct ConfigOptsWatch {
     #[arg(long)]
     #[serde(default)]
     pub poll: bool,
+    #[arg(long)]
+    #[serde(default)]
+    pub poll_interval: Option<ConfigDuration>,
     /// Allow disabling the cooldown
     #[arg(long)]
     #[serde(default)]
@@ -331,6 +356,7 @@ impl ConfigOpts {
             watch: cli.watch,
             ignore: cli.ignore,
             poll: cli.poll,
+            poll_interval: cli.poll_interval,
             ignore_cooldown: cli.ignore_cooldown,
         };
         let cfg = ConfigOpts {

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -98,8 +98,11 @@ pub struct ConfigOptsWatch {
     #[arg(short, long, value_name = "path")]
     pub ignore: Option<Vec<PathBuf>>,
     /// Using polling mode for detecting changes
-    #[arg(short, long)]
+    #[arg(long)]
     pub poll: bool,
+    /// Allow disabling the cooldown
+    #[arg(long)]
+    pub ignore_cooldown: bool,
 }
 
 /// Config options for the serve system.
@@ -326,6 +329,7 @@ impl ConfigOpts {
             watch: cli.watch,
             ignore: cli.ignore,
             poll: cli.poll,
+            ignore_cooldown: cli.ignore_cooldown,
         };
         let cfg = ConfigOpts {
             build: None,

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -99,9 +99,11 @@ pub struct ConfigOptsWatch {
     pub ignore: Option<Vec<PathBuf>>,
     /// Using polling mode for detecting changes
     #[arg(long)]
+    #[serde(default)]
     pub poll: bool,
     /// Allow disabling the cooldown
     #[arg(long)]
+    #[serde(default)]
     pub ignore_cooldown: bool,
 }
 

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -97,6 +97,9 @@ pub struct ConfigOptsWatch {
     /// Paths to ignore [default: []]
     #[arg(short, long, value_name = "path")]
     pub ignore: Option<Vec<PathBuf>>,
+    /// Using polling mode for detecting changes
+    #[arg(short, long)]
+    pub poll: bool,
 }
 
 /// Config options for the serve system.
@@ -322,6 +325,7 @@ impl ConfigOpts {
         let opts = ConfigOptsWatch {
             watch: cli.watch,
             ignore: cli.ignore,
+            poll: cli.poll,
         };
         let cfg = ConfigOpts {
             build: None,

--- a/src/config/rt.rs
+++ b/src/config/rt.rs
@@ -183,6 +183,8 @@ pub struct RtcWatch {
     pub paths: Vec<PathBuf>,
     /// Paths to ignore.
     pub ignored_paths: Vec<PathBuf>,
+    /// Use polling mode for detecting chnages
+    pub poll: bool,
 }
 
 impl RtcWatch {
@@ -230,6 +232,7 @@ impl RtcWatch {
             build,
             paths,
             ignored_paths,
+            poll: opts.poll,
         })
     }
 }

--- a/src/config/rt.rs
+++ b/src/config/rt.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr};
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{anyhow, ensure, Context, Result};
 use axum::http::Uri;
@@ -183,8 +184,8 @@ pub struct RtcWatch {
     pub paths: Vec<PathBuf>,
     /// Paths to ignore.
     pub ignored_paths: Vec<PathBuf>,
-    /// Use polling mode for detecting changes
-    pub poll: bool,
+    /// Polling mode for detecting changes if set to `Some(_)`.
+    pub poll: Option<Duration>,
     /// Allow disabling the cooldown
     pub ignore_cooldown: bool,
 }
@@ -234,7 +235,11 @@ impl RtcWatch {
             build,
             paths,
             ignored_paths,
-            poll: opts.poll,
+            poll: opts.poll.then(|| {
+                opts.poll_interval
+                    .map(|d| d.0)
+                    .unwrap_or_else(|| Duration::from_secs(5))
+            }),
             ignore_cooldown: opts.ignore_cooldown,
         })
     }

--- a/src/config/rt.rs
+++ b/src/config/rt.rs
@@ -183,8 +183,10 @@ pub struct RtcWatch {
     pub paths: Vec<PathBuf>,
     /// Paths to ignore.
     pub ignored_paths: Vec<PathBuf>,
-    /// Use polling mode for detecting chnages
+    /// Use polling mode for detecting changes
     pub poll: bool,
+    /// Allow disabling the cooldown
+    pub ignore_cooldown: bool,
 }
 
 impl RtcWatch {
@@ -233,6 +235,7 @@ impl RtcWatch {
             paths,
             ignored_paths,
             poll: opts.poll,
+            ignore_cooldown: opts.ignore_cooldown,
         })
     }
 }

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -130,6 +130,7 @@ impl WatchSystem {
             //
             // Given the difficult nature of this issue, we opt for using a cooldown period. Any changes
             // events processed within the cooldown period following a build will be ignored.
+            tracing::debug!("purging change events due to cooldown");
             if Instant::now().duration_since(self.last_build_finished) <= cooldown {
                 // Purge any other events in the queue.
                 while let Ok(_event) = self.watch_rx.try_recv() {}

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -90,7 +90,7 @@ impl WatchSystem {
             shutdown: BroadcastStream::new(shutdown.subscribe()),
             build_done_tx,
             last_build_finished: Instant::now(),
-            watcher_cooldown: (!cfg.ignore_cooldown).then(|| WATCHER_COOLDOWN),
+            watcher_cooldown: (!cfg.ignore_cooldown).then_some(WATCHER_COOLDOWN),
         })
     }
 

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -116,6 +116,12 @@ impl WatchSystem {
 
     #[tracing::instrument(level = "trace", skip(self, event))]
     async fn handle_watch_event(&mut self, event: DebouncedEvent) {
+        tracing::trace!(
+            "change detected in {:?} of type {:?}",
+            event.paths,
+            event.kind
+        );
+
         if let Some(cooldown) = self.watcher_cooldown {
             // There are various OS syscalls which can trigger FS changes, even though semantically no
             // changes were made. A notorious example which has plagued the trunk watcher
@@ -166,7 +172,7 @@ impl WatchSystem {
             }
 
             // If all of the above checks have passed, then we need to trigger a build.
-            tracing::debug!("change detected in {:?} of type {:?}", ev_path, event.kind);
+            tracing::debug!("accepted change in {:?} of type {:?}", ev_path, event.kind);
             found_matching_path = true;
         }
 


### PR DESCRIPTION
This is currently a draft PR in order to gather some feedback if that improves the situation.

It basically provides what `cargo-watch` offers too: https://github.com/watchexec/cargo-watch/blob/ee43124fdd97c9a81eb20c0d834ed1406e15cd72/src/args.rs#L78-L82

Testing this should be possible by performing a local installation from git:

```shell
cargo install --git https://github.com/ctron/trunk --branch feature/add_poll_1 trunk
```

Once installed, there are two new options for `watch` and `serve`:

```
      --poll                           Using polling mode for detecting changes
      --ignore-cooldown                Allow disabling the cooldown
```

**NOTE:** Both options are experimental to better understand the problem!

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [ ] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [ ] Updated `site` content with pertinent info (may not always apply).
- [ ] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
