### PR TITLE
Fix version matching for sass compiled with dart2js

### DIFF
--- a/src/tools.rs
+++ b/src/tools.rs
@@ -157,7 +157,7 @@ impl Application {
         let text = text.trim();
         let formatted_version = match self {
             Application::Sass => text
-                .lines()
+                .split_whitespace()
                 .next()
                 .with_context(|| format!("missing or malformed version output: {}", text))?
                 .to_owned(),
@@ -651,6 +651,7 @@ mod tests {
     );
 
     table_test_format_version!(sass_pre_compiled, Application::Sass, "1.37.5", "1.37.5");
+    table_test_format_version!(sass_pre_compiled_dart2js, Application::Sass, "1.37.5 compiled with dart2js 2.18.4", "1.37.5");
     table_test_format_version!(
         tailwindcss_pre_compiled,
         Application::TailwindCss,


### PR DESCRIPTION
sass may report the version differently if it's the nodejs version of dart-sass:

```sh
$ sass --version
1.62.1 compiled with dart2js 2.19.6
```

I would expect the version to be `1.62.1`, but currently trunk thinks it's `1.62.1 compiled with dart2js 2.19.6`.

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [ ] Updated CHANGELOG.md describing pertinent changes.
- [ ] Updated README.md with pertinent info (may not always apply).
- [ ] Updated `site` content with pertinent info (may not always apply).
- [ ] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.

Fixes: #541