### PR TITLE
watch: match on `All` event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 ## Unreleased
 ### changed
 - Remove HTML glob in tailwind.config.js
+- Add "All" to watch events to enable reloading when `notify` can't report the watch event type
 
 ## 0.17.4
 ### added

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -117,7 +117,7 @@ impl WatchSystem {
 
         // Check each path in the event for a match.
         match event.event.kind {
-            EventKind::Modify(ModifyKind::Name(_) | ModifyKind::Data(_))
+            EventKind::Modify(ModifyKind::Name(_) | ModifyKind::Data(_) | ModifyKind::Any)
             | EventKind::Create(_)
             | EventKind::Remove(_) => (),
             _ => return,


### PR DESCRIPTION
Some platforms don't support precise notification kinds and instead report `All` as an event kind. This is what the notification system reports when it doesn't know what else to report.

It's also the kind that's used in "imprecise" mode.

This fixes watching on Windows, and may address issues reported in #232.

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [-] Updated README.md with pertinent info (may not always apply).
- [-] Updated `site` content with pertinent info (may not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
