### PR TITLE
Use `--target=web` for WebWorkers

### DIFF
--- a/site/content/assets.md
+++ b/site/content/assets.md
@@ -33,6 +33,7 @@ This will typically look like: `<link data-trunk rel="{type}" href="{path}" ..ot
   - `data-reference-types`: (optional) instruct `wasm-bindgen` to enable [reference types](https://rustwasm.github.io/docs/wasm-bindgen/reference/reference-types.html).
   - `data-weak-refs`: (optional) instruct `wasm-bindgen` to enable [weak references](https://rustwasm.github.io/docs/wasm-bindgen/reference/weak-references.html).
   - `data-typescript`: (optional) instruct `wasm-bindgen` to output Typescript bindings. Defaults to false.
+  - `data-bindgen-target`: (optional) specifies the value of the `wasm-bindgen` flag [`--target`](https://rustwasm.github.io/wasm-bindgen/reference/deployment.html) (see link for possible values). Defaults to `web`. The main use-case is to switch to `no-modules` with `data-type="worker"` for backwards [compatibility](https://caniuse.com/mdn-api_worker_worker_ecmascript_modules) but with some [disadvantages](https://rustwasm.github.io/wasm-bindgen/examples/without-a-bundler.html?highlight=no-modules#using-the-older---target-no-modules).
   - `data-loader-shim`: (optional) instruct `trunk` to create a loader shim for web workers. Defaults to false.
   - `data-cross-origin`: (optional) the `crossorigin` setting when loading the code & script resources. Defaults to plain `anonymous`.
   - `data-integrity`: (optional) the `integrity` digest type for code & script resources. Defaults to plain `sha384`.


### PR DESCRIPTION
I ran into the following error when using a web worker which uses a JS snippet (namely, using the [`viz_js`](https://crates.io/crates/viz-js) crate in a web worker):
```
error: importing from `...` isn't supported with `--target no-modules`
```
I didn't dig into it too much, but [this](https://rustwasm.github.io/wasm-bindgen/examples/without-a-bundler.html?highlight=no-modules#using-the-older---target-no-modules) page seems to explain the issue. So, as this PR does, I tried to naively change to `--target=web` in trunk and this resolved the above error for me.

Not sure why @kristoff3r chose to use `--target=no-modules` in https://github.com/thedodd/trunk/pull/285, maybe there is some advantage? If there is some reason for `no-modules` then it would at least be nice to be able to toggle this in a config.

**Checklist**
- [x] Updated CHANGELOG.md describing pertinent changes.
- [x] Updated README.md with pertinent info (may not always apply).
- [x] Updated `site` content with pertinent info (may not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done. If you don't, then Dodd will 🤓.
