### PR TITLE
fix: Use "global" mode for classic scripts

### DIFF
--- a/examples/vanilla/index.html
+++ b/examples/vanilla/index.html
@@ -12,6 +12,7 @@
 <body>
     <link data-trunk rel="rust" href="Cargo.toml" data-wasm-opt="z" data-bin="vanilla-example"/>
     <script data-trunk src="src/script.js"></script>
+    <script data-trunk src="src/script.mjs" type="module"></script>
 </body>
 <script>testFromJavaScript();</script>
 </html>

--- a/examples/vanilla/src/script.mjs
+++ b/examples/vanilla/src/script.mjs
@@ -1,0 +1,5 @@
+function testFromJavaScriptModule() {
+  console.log("Hello from JavaScript Module");
+}
+
+testFromJavaScriptModule();

--- a/src/processing/minify.rs
+++ b/src/processing/minify.rs
@@ -1,0 +1,12 @@
+use anyhow::anyhow;
+use minify_js::TopLevelMode;
+
+/// perform JS minification
+pub fn minify_js(bytes: &[u8], mode: TopLevelMode) -> anyhow::Result<Vec<u8>> {
+    let mut result: Vec<u8> = vec![];
+    let session = minify_js::Session::new();
+    minify_js::minify(&session, mode, bytes, &mut result)
+        .map_err(|err| anyhow!("Failed to minify JS: {err}"))?;
+
+    Ok(result)
+}

--- a/src/processing/mod.rs
+++ b/src/processing/mod.rs
@@ -1,3 +1,4 @@
 //! Functionality for processing
 
 pub mod integrity;
+pub mod minify;


### PR DESCRIPTION
When minifying JS, use the "global" mode for classic scripts and "module" for `type="module"`.

Closes: #629