### PR TITLE
fix: uptick default wasm_bindgen to 0.2.89, as 0.2.88 got yanked

### DIFF
--- a/Trunk.toml
+++ b/Trunk.toml
@@ -59,7 +59,7 @@ cargo = false
 # Default dart-sass version to download.
 sass = "1.69.5"
 # Default wasm-bindgen version to download.
-wasm_bindgen = "0.2.88"
+wasm_bindgen = "0.2.89"
 # Default wasm-opt version to download.
 wasm_opt = "version_116"
 # Default tailwindcss-cli version to download.

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -100,7 +100,7 @@ impl Application {
         match self {
             Self::Sass => "1.69.5",
             Self::TailwindCss => "3.3.5",
-            Self::WasmBindgen => "0.2.88",
+            Self::WasmBindgen => "0.2.89",
             Self::WasmOpt => "version_116",
         }
     }


### PR DESCRIPTION
Closes: #644