### PR TITLE
fix: ignore failures during minification

### DIFF
--- a/src/pipelines/html.rs
+++ b/src/pipelines/html.rs
@@ -181,7 +181,7 @@ impl HtmlPipeline {
 
         // Assemble a new output index.html file.
         let output_html = match self.cfg.release && !self.cfg.no_minification {
-            true => minify_html(target_html.html().as_bytes())?,
+            true => minify_html(target_html.html().as_bytes()),
             false => target_html.html().as_bytes().to_vec(),
         };
 

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -257,7 +257,7 @@ impl AssetFile {
 
         bytes = if minify {
             match file_type {
-                AssetFileType::Css => minify_css(bytes)?,
+                AssetFileType::Css => minify_css(bytes),
                 AssetFileType::Icon(image_type) => match image_type {
                     ImageType::Png => oxipng::optimize_from_memory(
                         bytes.as_ref(),
@@ -266,8 +266,8 @@ impl AssetFile {
                     .with_context(|| format!("error optimizing PNG {:?}", &self.path))?,
                     ImageType::Other => bytes,
                 },
-                AssetFileType::Js => minify_js(&bytes, TopLevelMode::Global)?,
-                AssetFileType::Mjs => minify_js(&bytes, TopLevelMode::Module)?,
+                AssetFileType::Js => minify_js(bytes, TopLevelMode::Global),
+                AssetFileType::Mjs => minify_js(bytes, TopLevelMode::Module),
                 _ => bytes,
             }
         } else {

--- a/src/pipelines/rust/mod.rs
+++ b/src/pipelines/rust/mod.rs
@@ -679,7 +679,7 @@ impl RustApp {
             .context("error reading JS loader file")?;
 
         let write_bytes = match self.cfg.release && !self.cfg.no_minification {
-            true => minify_js(&bytes, mode).unwrap_or(bytes),
+            true => minify_js(bytes, mode),
             false => bytes,
         };
 

--- a/src/processing/minify.rs
+++ b/src/processing/minify.rs
@@ -1,35 +1,40 @@
-use anyhow::anyhow;
 use minify_js::TopLevelMode;
 
 /// perform JS minification
-pub fn minify_js(bytes: &[u8], mode: TopLevelMode) -> anyhow::Result<Vec<u8>> {
+pub fn minify_js(bytes: Vec<u8>, mode: TopLevelMode) -> Vec<u8> {
     let mut result: Vec<u8> = vec![];
     let session = minify_js::Session::new();
-    minify_js::minify(&session, mode, bytes, &mut result)
-        .map_err(|err| anyhow!("Failed to minify JS: {err}"))?;
 
-    Ok(result)
-}
-
-/// perform CSS minification
-pub fn minify_css(bytes: Vec<u8>) -> anyhow::Result<Vec<u8>> {
-    use css_minify::optimizations::*;
-
-    if let Ok(css) = std::str::from_utf8(&bytes) {
-        Ok(Minifier::default()
-            .minify(css, Level::Three)
-            .map_err(|err| anyhow!("Failed to minify CSS: {err}"))?
-            .into_bytes())
-    } else {
-        Ok(bytes)
+    match minify_js::minify(&session, mode, &bytes, &mut result) {
+        Ok(()) => result,
+        Err(err) => {
+            tracing::warn!("Failed to minify JS: {err}");
+            bytes
+        }
     }
 }
 
+/// perform CSS minification
+pub fn minify_css(bytes: Vec<u8>) -> Vec<u8> {
+    use css_minify::optimizations::*;
+
+    if let Ok(css) = std::str::from_utf8(&bytes) {
+        match Minifier::default().minify(css, Level::Three) {
+            Ok(result) => return result.into_bytes(),
+            Err(err) => {
+                tracing::warn!("Failed to minify CSS: {err}");
+            }
+        }
+    }
+
+    bytes
+}
+
 /// perform HTML minification
-pub fn minify_html(html: &[u8]) -> anyhow::Result<Vec<u8>> {
+pub fn minify_html(html: &[u8]) -> Vec<u8> {
     let mut minify_cfg = minify_html::Cfg::spec_compliant();
     minify_cfg.minify_css = true;
     minify_cfg.minify_js = true;
     minify_cfg.keep_closing_tags = true;
-    Ok(minify_html::minify(html, &minify_cfg))
+    minify_html::minify(html, &minify_cfg)
 }

--- a/src/processing/minify.rs
+++ b/src/processing/minify.rs
@@ -19,7 +19,7 @@ pub fn minify_css(bytes: Vec<u8>) -> Vec<u8> {
     use css_minify::optimizations::*;
 
     if let Ok(css) = std::str::from_utf8(&bytes) {
-        match Minifier::default().minify(css, Level::Three) {
+        match Minifier::default().minify(css, Level::One) {
             Ok(result) => return result.into_bytes(),
             Err(err) => {
                 tracing::warn!("Failed to minify CSS: {err}");


### PR DESCRIPTION
If minification fails, then simply use the original content.