### PR TITLE
feat: improve error message for tool version error

### DIFF
--- a/src/cmd/tools.rs
+++ b/src/cmd/tools.rs
@@ -33,7 +33,7 @@ pub enum ToolsSubcommands {
 
 async fn show_tools() {
     for app in tools::Application::iter() {
-        let (path, version) = find_system(app, None).await.unzip();
+        let (path, version) = find_system(app).await.unzip();
         let path = OrNone(path.map(|p| p.display().to_string()));
         let version = OrNone(version);
 


### PR DESCRIPTION
In case of using --offline, and requiring a specific version of a tool, the error just says "not found". However, it would be more helpful to indicate that the tool was found, but was of the wrong version ("version mismatch").

Closes: #650