### PR TITLE
fix: persist headers on ws handshake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2934,7 +2934,9 @@ dependencies = [
  "log",
  "rustls",
  "tokio",
+ "tokio-rustls",
  "tungstenite",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3249,6 +3251,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
+ "rustls",
  "sha1",
  "thiserror",
  "url",
@@ -3463,6 +3466,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
 
 [[package]]
 name = "which"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ tar = "0.4"
 thiserror = "1"
 tokio = { version = "1", default-features = false, features = ["full"] }
 tokio-stream = { version = "0.1", default-features = false, features = ["fs", "sync"] }
-tokio-tungstenite = { version = "0.20", features = ["rustls"] }
+tokio-tungstenite = { version = "0.20", features = ["rustls", "rustls-tls-webpki-roots"] }
 toml = "0.8"
 tower-http = { version = "0.4", features = ["fs", "trace", "set-header"] }
 tracing = "0.1"


### PR DESCRIPTION
Currently when using the WebSocket Proxy, headers are not sent to the outbound request that
performs the upgrade request/handshake.

Here headers from incoming request are mapped to the outbound request to allow for
authentication.

In order to open to TLS/SSL connections the feature: `rustls-tls-webpki-roots` is also
enabled.