### PR TITLE
not add prefix / for public-url and default to ./

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -204,3 +204,17 @@ pub fn check_target_not_found_err(err: anyhow::Error, target: &str) -> anyhow::E
         _ => err,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_public_url() {
+        assert_eq!(parse_public_url("."), Ok("./".to_owned()));
+        assert_eq!(parse_public_url("./"), Ok("./".to_owned()));
+        assert_eq!(parse_public_url("abc"), Ok("abc/".to_owned()));
+        assert_eq!(parse_public_url("abc/"), Ok("abc/".to_owned()));
+        assert_eq!(parse_public_url("/abc"), Ok("/abc/".to_owned()));
+    }
+}

--- a/src/common.rs
+++ b/src/common.rs
@@ -27,13 +27,8 @@ static CWD: Lazy<PathBuf> =
 
 /// Ensure the given value for `--public-url` is formatted correctly.
 pub fn parse_public_url(val: &str) -> Result<String, Infallible> {
-    let prefix = if val.starts_with('/') || val.starts_with("./") {
-        ""
-    } else {
-        "/"
-    };
     let suffix = if !val.ends_with('/') { "/" } else { "" };
-    Ok(format!("{}{}{}", prefix, val, suffix))
+    Ok(format!("{}{}", val, suffix))
 }
 
 /// A utility function to recursively copy a directory.

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -47,7 +47,7 @@ pub struct ConfigOptsBuild {
     #[serde(default)]
     pub locked: bool,
 
-    /// Build without downloading required tools [default: false]
+    /// The public URL from which assets are to be served [default: ./]
     #[arg(long, value_parser = parse_public_url)]
     pub public_url: Option<String>,
 

--- a/src/config/rt.rs
+++ b/src/config/rt.rs
@@ -140,7 +140,7 @@ impl RtcBuild {
             target,
             target_parent,
             release: opts.release,
-            public_url: opts.public_url.unwrap_or_else(|| "/".into()),
+            public_url: opts.public_url.unwrap_or_else(|| "./".to_owned()),
             filehash: opts.filehash.unwrap_or(true),
             staging_dist,
             final_dist,

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -246,13 +246,10 @@ impl State {
 /// (for autoreload & HMR in the future), as well as any user-defined proxies.
 fn router(state: Arc<State>, cfg: Arc<RtcServe>) -> Result<Router> {
     // Build static file server, middleware, error handler & WS route for reloads.
-    let public_route = if state.public_url == "/" {
+    let public_route = if state.public_url.starts_with('/') {
         &state.public_url
     } else {
-        state
-            .public_url
-            .strip_suffix('/')
-            .unwrap_or(&state.public_url)
+        "/"
     };
 
     let mut serve_dir = if cfg.no_spa {


### PR DESCRIPTION
This is an implementation for #668 .

I planned to add checking prefix '.' and 'https://' to avoid breaking changes. However, I see that there's already a lot of discussion and  breaking changes are considered so I implemented as #668 .

Also fix docs of `public_url` which is wrong since 7acf4cdfa507c4e67d003cedfcb0c998ba76e1cf.