### PR TITLE
fix: await all asset pipeline, even if some fail

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3227,7 +3227,7 @@ dependencies = [
 
 [[package]]
 name = "trunk"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trunk"
-version = "0.18.4"
+version = "0.18.5"
 edition = "2021"
 description = "Build, bundle & ship your Rust WASM application to the web."
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
When a pipeline step fails, the while loop will fail fast, but this will leave all other tasks still running in the background. Which might lead to the case where longer running tasks (like cargo build) run, while others abort the build.

Having a case like this, might also lead to multiple cargo builds stacking up in the background.

It also might lead to the case where a failure, due to a missing directory, will repeated, as repeated builds are triggered by the initial cargo build. Because only after the initial cargo build, the target folder will be ignored. But as the build fails fast, a new build will be triggered, as changes to the target folder are not yet ignored.

Closes: https://github.com/trunk-rs/trunk/issues/662