### PR TITLE
Use original artifact name when generating intermediate files

### DIFF
--- a/examples/vanilla/src/main.rs
+++ b/examples/vanilla/src/main.rs
@@ -5,10 +5,13 @@ use wasm_bindgen::prelude::*;
 use web_sys::window;
 
 fn start_app() {
-    let document = window().and_then(|win| win.document()).expect("Could not access document");
+    let document = window()
+        .and_then(|win| win.document())
+        .expect("Could not access document");
     let body = document.body().expect("Could not access document.body");
     let text_node = document.create_text_node("Hello, world from Vanilla Rust!");
-    body.append_child(text_node.as_ref()).expect("Failed to append text");
+    body.append_child(text_node.as_ref())
+        .expect("Failed to append text");
 }
 
 #[wasm_bindgen(inline_js = "export function snippetTest() { console.log('Hello from JS FFI!'); }")]


### PR DESCRIPTION
Using the hashed name will lead to a lot of intermediate files which need cleanup. Without really serving much purpose, as the files will never be re-used.

Closes: https://github.com/trunk-rs/trunk/issues/659