### PR TITLE
refactor: switch css minification to lighteningcss

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,17 +633,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "css-minify"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874c6e2d19f8d4a285083b11a3241bfbe01ac3ed85f26e1e6b34888d960552bd"
-dependencies = [
- "derive_more",
- "indexmap 1.9.3",
- "nom",
-]
-
-[[package]]
 name = "cssparser"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1090,7 +1079,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.1.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -1295,16 +1284,6 @@ checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1688,12 +1667,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1774,16 +1747,6 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
 
 [[package]]
 name = "normpath"
@@ -1909,7 +1872,7 @@ dependencies = [
  "env_logger",
  "filetime",
  "glob",
- "indexmap 2.1.0",
+ "indexmap",
  "libdeflater",
  "log",
  "rayon",
@@ -3256,7 +3219,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3269,7 +3232,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3406,7 +3369,6 @@ dependencies = [
  "cargo_metadata",
  "clap",
  "console",
- "css-minify",
  "directories",
  "dunce",
  "envy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ cargo-lock = "9"
 cargo_metadata = "0.18.1"
 clap = { version = "4", features = ["derive", "env"] }
 console = "0.15"
-css-minify = "0.3"
 directories = "5"
 dunce = "1"
 envy = "0.4"
@@ -76,7 +75,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 which = "5"
 zip = "0.6"
 
-# pin lightningcss, pulled in by minify-html
+# pin lightningcss, used by trunk, also pulled in by minify-html
 lightningcss = "=1.0.0-alpha.51"
 
 [dev-dependencies]

--- a/src/processing/minify.rs
+++ b/src/processing/minify.rs
@@ -16,18 +16,35 @@ pub fn minify_js(bytes: Vec<u8>, mode: TopLevelMode) -> Vec<u8> {
 
 /// perform CSS minification
 pub fn minify_css(bytes: Vec<u8>) -> Vec<u8> {
-    use css_minify::optimizations::*;
+    use lightningcss::stylesheet::*;
 
-    if let Ok(css) = std::str::from_utf8(&bytes) {
-        match Minifier::default().minify(css, Level::One) {
-            Ok(result) => return result.into_bytes(),
-            Err(err) => {
-                tracing::warn!("Failed to minify CSS: {err}");
-            }
-        }
+    /// wrap CSS minification to isolate borrowing the original content
+    fn minify(css: &str) -> Result<String, ()> {
+        // parse CSS
+
+        let mut css = StyleSheet::parse(css, ParserOptions::default()).map_err(|err| {
+            tracing::warn!("CSS parsing failed, skipping: {err}");
+        })?;
+
+        css.minify(MinifyOptions::default()).map_err(|err| {
+            tracing::warn!("CSS minification failed, skipping: {err}");
+        })?;
+
+        Ok(css
+            .to_css(PrinterOptions {
+                minify: true,
+                ..Default::default()
+            })
+            .map_err(|err| {
+                tracing::warn!("CSS generation failed, skipping: {err}");
+            })?
+            .code)
     }
 
-    bytes
+    match std::str::from_utf8(&bytes) {
+        Ok(css) => minify(css).map(String::into_bytes).unwrap_or(bytes),
+        Err(_) => bytes,
+    }
 }
 
 /// perform HTML minification


### PR DESCRIPTION
lighteningcss already got pulled in through a minify-html upgrade. So we now to have use that pinned version anyway, and we can go ahead, dropping css-minify.

Replaces: #654