### PR TITLE
doc: help message is incorrect for --public-url

### DIFF
--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -45,7 +45,7 @@ pub struct ConfigOptsBuild {
     #[serde(default)]
     pub locked: bool,
 
-    /// Build without downloading required tools [default: false]
+    /// The public URL from which assets are to be served
     #[arg(long, value_parser = parse_public_url)]
     pub public_url: Option<String>,
 


### PR DESCRIPTION
This should address https://github.com/trunk-rs/trunk/issues/702