### PR TITLE
feat: add required trunk version, and update version check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,6 +99,10 @@ jobs:
       - name: Build | Run
         run: cargo run -- -h
 
+      # Run the CLI to, testing the default config
+      - name: Build | Test default config
+        run: cargo run -- config show
+
       # Upload the debug binary for testing examples later
       - name: Upload | For testing
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,10 +99,6 @@ jobs:
       - name: Build | Run
         run: cargo run -- -h
 
-      # Run the CLI to, testing the default config
-      - name: Build | Test default config
-        run: cargo run -- config show
-
       # Upload the debug binary for testing examples later
       - name: Upload | For testing
         uses: actions/upload-artifact@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1541,9 +1541,9 @@ dependencies = [
 
 [[package]]
 name = "lightningcss"
-version = "1.0.0-alpha.51"
+version = "1.0.0-alpha.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d6ad516c08b24c246b339159dc2ee2144c012e8ebdf4db4bddefb8734b2b69"
+checksum = "771a62dedf5ec563bbfea9760f6c6a6bc546e67355eba0cd7d00c0dc34b11d90"
 dependencies = [
  "ahash 0.7.7",
  "bitflags 2.4.2",
@@ -2994,18 +2994,18 @@ checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "strum"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+checksum = "723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2faccea4cc4ab4a667ce676a30e8ec13922a692c99bb8f5b11f1502c72e04220"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
 name = "anstyle-parse"
@@ -333,9 +333,9 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "bytecheck"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6372023ac861f6e6dc89c8344a8f398fb42aaba2b5dbc649ca0c0e9dbcb627"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
 dependencies = [
  "bytecheck_derive",
  "ptr_meta",
@@ -344,9 +344,9 @@ dependencies = [
 
 [[package]]
 name = "bytecheck_derive"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ec4c6f261935ad534c0c22dbef2201b45918860eb1c574b972bd213a76af61"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -355,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.14.1"
+version = "1.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2490600f404f2b94c167e31d3ed1d5f3c225a0f3b80230053b3e0b7b962bd9"
+checksum = "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f"
 
 [[package]]
 name = "byteorder"
@@ -415,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceed8ef69d8518a5dda55c07425450b58a4e1946f4951eab6d7191ee86c2443d"
+checksum = "694c8807f2ae16faecc43dc17d74b3eb042482789fd0eb64b39a2e04e087053f"
 dependencies = [
  "serde",
 ]
@@ -453,6 +453,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
+dependencies = [
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.18"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+checksum = "80c21025abd42669a92efc996ef13cfb2c5c627858421ea58d5c3b331a6c134f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -474,9 +484,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.18"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+checksum = "458bf1f341769dfcf849846f65dffdf9146daa56bcd2a47cb4e1de9915567c99"
 dependencies = [
  "anstream",
  "anstyle",
@@ -487,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -499,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "colorchoice"
@@ -577,6 +587,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crates_io_api"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0122a67287f6795360b83a542cf2fbb3eb57a42729966c9ac792598c909902"
+dependencies = [
+ "chrono",
+ "futures",
+ "reqwest",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_path_to_error",
+ "tokio",
+ "url",
 ]
 
 [[package]]
@@ -725,6 +752,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -954,12 +982,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -967,6 +1011,17 @@ name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -1003,6 +1058,7 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1119,9 +1175,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
+checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
 
 [[package]]
 name = "hmac"
@@ -1355,12 +1411,12 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
+checksum = "fe8f25ce1159c7740ff0b9b2f5cdf4a8428742ba7c112b9f20f22cd5219c7dab"
 dependencies = [
  "hermit-abi",
- "rustix",
+ "libc",
  "windows-sys 0.52.0",
 ]
 
@@ -1406,18 +1462,18 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
+checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1668,9 +1724,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
 ]
@@ -1805,6 +1861,15 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-traits"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "num_cpus"
@@ -2424,9 +2489,9 @@ dependencies = [
 
 [[package]]
 name = "rend"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2571463863a6bd50c32f94402933f03457a3fbaf697a707c5be741e459f08fd"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
 dependencies = [
  "bytecheck",
 ]
@@ -2472,6 +2537,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -2510,9 +2576,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.43"
+version = "0.7.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527a97cdfef66f65998b5f3b637c26f5a5ec09cc52a3f9932313ac645f4190f5"
+checksum = "5cba464629b3394fc4dbc6f940ff8f5b4ff5c7aef40f29166fd4ad12acbc99c0"
 dependencies = [
  "bitvec",
  "bytecheck",
@@ -2528,9 +2594,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.43"
+version = "0.7.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5c462a1328c8e67e4d6dbad1eb0355dd43e8ab432c6e227a43657f16ade5033"
+checksum = "a7dddfff8de25e6f62b9d64e6e432bf1c6736c57d20323e15ee10435fbda7c65"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2922,9 +2988,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "strum"
@@ -3022,13 +3088,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.9.0"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
+checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -3101,15 +3166,17 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe80ced77cbfb4cb91a94bf72b378b4b6791a0d9b7f09d0be747d1bdff4e68bd"
+checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
 dependencies = [
  "deranged",
+ "itoa 1.0.10",
  "num-conv",
  "powerfmt",
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -3117,6 +3184,16 @@ name = "time-core"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinyvec"
@@ -3228,14 +3305,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6a4b9e8023eb94392d3dca65d717c53abc5dad49c07cb65bb8fcd87115fa325"
+checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.21.1",
+ "toml_edit 0.22.4",
 ]
 
 [[package]]
@@ -3262,9 +3339,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+checksum = "0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951"
 dependencies = [
  "indexmap",
  "serde",
@@ -3390,7 +3467,7 @@ dependencies = [
 
 [[package]]
 name = "trunk"
-version = "0.19.0-alpha.1"
+version = "0.19.0-alpha.2"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -3403,6 +3480,7 @@ dependencies = [
  "cargo_metadata",
  "clap",
  "console",
+ "crates_io_api",
  "directories",
  "dunce",
  "envy",
@@ -3428,6 +3506,7 @@ dependencies = [
  "remove_dir_all",
  "reqwest",
  "seahash",
+ "semver",
  "serde",
  "serde_json",
  "sha2",
@@ -3435,10 +3514,11 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror",
+ "time",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
- "toml 0.8.9",
+ "toml 0.8.10",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -3652,9 +3732,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
+checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3662,9 +3742,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
+checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
 dependencies = [
  "bumpalo",
  "log",
@@ -3677,9 +3757,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
+checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3689,9 +3769,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
+checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3699,9 +3779,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
+checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3712,9 +3792,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
+checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
 
 [[package]]
 name = "wasm-streams"
@@ -3731,13 +3811,19 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
+checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "which"
@@ -3989,9 +4075,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.36"
+version = "0.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818ce546a11a9986bc24f93d0cdf38a8a1a400f1473ea8c82e59f6e0ffab9249"
+checksum = "5389a154b01683d28c77f8f68f49dea75f0a4da32557a58f68ee51ebba472d29"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trunk"
-version = "0.19.0-alpha.1"
+version = "0.19.0-alpha.2"
 edition = "2021"
 description = "Build, bundle & ship your Rust WASM application to the web."
 license = "MIT/Apache-2.0"
@@ -29,6 +29,7 @@ base64 = "0.21"
 bytes = "1"
 cargo-lock = "9"
 cargo_metadata = "0.18.1"
+crates_io_api = { version = "0.9", default-features = false, features = ["rustls"] }
 clap = { version = "4", features = ["derive", "env"] }
 console = "0.15"
 directories = "5"
@@ -60,10 +61,12 @@ reqwest = { version = "0.11", default-features = false, features = [
 ] }
 sha2 = "0.10"
 seahash = { version = "4", features = ["use_std"] }
+semver = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 strum = { version = "0.25", features = ["derive"] }
 tar = "0.4"
+time = { version = "0.3", features = ["serde-well-known"] }
 thiserror = "1"
 tokio = { version = "1", default-features = false, features = ["full"] }
 tokio-stream = { version = "0.1", default-features = false, features = ["fs", "sync"] }
@@ -80,3 +83,9 @@ lightningcss = "=1.0.0-alpha.51"
 
 [dev-dependencies]
 tempfile = "3"
+
+[features]
+default = ["update_check"]
+
+# enable the update check once on startup
+update_check = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ seahash = { version = "4", features = ["use_std"] }
 semver = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-strum = { version = "0.25", features = ["derive"] }
+strum = { version = "0.26", features = ["derive"] }
 tar = "0.4"
 time = { version = "0.3", features = ["serde-well-known"] }
 thiserror = "1"
@@ -79,7 +79,7 @@ which = "6"
 zip = "0.6"
 
 # pin lightningcss, used by trunk, also pulled in by minify-html
-lightningcss = "=1.0.0-alpha.51"
+lightningcss = "=1.0.0-alpha.52"
 
 [dev-dependencies]
 tempfile = "3"

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -1,5 +1,8 @@
 # An example Trunk.toml with all possible fields along with their defaults.
 
+# A sem-ver version requirement of trunk required for this project
+trunk-version = "*"
+
 [build]
 # The index HTML file to drive the bundling process.
 target = "index.html"

--- a/examples/initializer/Cargo.lock
+++ b/examples/initializer/Cargo.lock
@@ -25,6 +25,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "initializer-example"
+version = "0.1.0"
+dependencies = [
+ "console_error_panic_hook",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,15 +88,6 @@ name = "unicode-ident"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
-
-[[package]]
-name = "vanilla-example"
-version = "0.1.0"
-dependencies = [
- "console_error_panic_hook",
- "wasm-bindgen",
- "web-sys",
-]
 
 [[package]]
 name = "wasm-bindgen"

--- a/examples/initializer/Cargo.toml
+++ b/examples/initializer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "vanilla-example"
+name = "initializer-example"
 version = "0.1.0"
-authors = ["Philip Peterson <pc.peterso@gmail.com>"]
+authors = ["Jens Reimann <ctron@dentrassi.de>"]
 edition = "2018"
 
 [dependencies]

--- a/examples/initializer/index.html
+++ b/examples/initializer/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -9,6 +9,6 @@
     <base data-trunk-public-url/>
 </head>
 <body>
-    <link data-trunk rel="rust" href="Cargo.toml" data-wasm-opt="z" data-bin="vanilla-example" data-initializer="src/initializer.mjs"/>
+    <link data-trunk rel="rust" href="Cargo.toml" data-wasm-opt="z" data-bin="initializer-example" data-initializer="src/initializer.mjs"/>
 </body>
 </html>

--- a/examples/initializer/src/main.rs
+++ b/examples/initializer/src/main.rs
@@ -1,7 +1,6 @@
 #![recursion_limit = "1024"]
 
 use console_error_panic_hook::set_once as set_panic_hook;
-use wasm_bindgen::prelude::*;
 use web_sys::window;
 
 fn start_app() {

--- a/site/content/advanced.md
+++ b/site/content/advanced.md
@@ -72,3 +72,14 @@ export default function myInitializer () {
 ```
 
 For a full example see: <https://github.com/trunk-rs/trunk/examples/initializer>.
+
+## Update check
+
+Trunk has an update check built in. By default, it will check the `trunk` crate on `crates.io` for a newer
+(non pre-release) version. If one is found, the information will be shown in the command line.
+
+This check can be disabled entirely, but not enabled the cargo feature `update_check`. It can also be disabled during
+runtime using the environment variable `TRUNK_SKIP_VERSION_CHECK`, or using the command line switch
+`--skip-version-check`.
+
+The check is only performed every 24 hours.

--- a/site/content/commands.md
+++ b/site/content/commands.md
@@ -22,3 +22,6 @@ Trunk leverages Rust's powerful concurrency primitives for maximum build speeds 
 
 # config show
 `trunk config show` prints out Trunk's current config, before factoring in CLI arguments. Nice for testing & debugging.
+
+# tools show
+`trunk tools show` prints out information about tools required by trunk and the project. It shows which tools are expected and which are found. 

--- a/site/content/configuration.md
+++ b/site/content/configuration.md
@@ -14,6 +14,9 @@ Note that any relative paths declared in a `Trunk.toml` file will be treated as 
 # Environment Variables
 Trunk environment variables mirror the `Trunk.toml` config schema. All Trunk environment variables have the following 3 part form `TRUNK_<SECTION>_<ITEM>`, where `TRUNK_` is the required prefix, `<SECTION>` is one of the `Trunk.toml` sections, and `<ITEM>` is a specific configuration item from the corresponding section. E.G., `TRUNK_SERVE_PORT=80` will cause `trunk serve` to listen on port `80`. The equivalent CLI invocation would be `trunk serve --port=80`.
 
+In addition, there is the variable `TRUNK_SKIP_VERSION_CHECK` which allows to control the update check (if that is)
+compiled into the version of trunk.
+
 # CLI Arguments & Options
 The final configuration layer is the CLI itself. Any arguments / options provided on the CLI will take final precedence over any other config layer.
 
@@ -45,3 +48,19 @@ The following is a snippet from the `Trunk.toml` file in the Trunk repo:
 rewrite = "/api/v1/"
 backend = "http://localhost:9000/"
 ```
+
+### Required version
+
+Starting with `0.19.0-alpha.2`, it is possible to enforce having a certain version of trunk building the project.
+
+As new features get added to trunk, this might be helpful to ensure that the version of trunk building the current
+is actually capable of doing so. This can be done using the `trunk-version` (or using the alias `trunk_version`) on
+the **root** level of the `Trunk.toml` file.
+
+The version format is a "version requirement", the same format you might know from Cargo's version field on
+dependencies.
+
+This also supports pre-release requirements, which allows to adopt upcoming features early.
+
+**NOTE:** Versions prior do `0.19.0-alpha.2` currently do not support this check, and so they will silently ignore
+such an error for now.

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -5,6 +5,7 @@ use clap::Args;
 
 use crate::build::BuildSystem;
 use crate::config::{ConfigOpts, ConfigOptsBuild};
+use crate::version::enforce_version;
 
 /// Build the Rust WASM app and all of its assets.
 #[derive(Clone, Debug, Args)]
@@ -18,6 +19,8 @@ impl Build {
     #[tracing::instrument(level = "trace", skip(self, config))]
     pub async fn run(self, config: Option<PathBuf>) -> Result<()> {
         let cfg = ConfigOpts::rtc_build(self.build, config)?;
+        enforce_version(&cfg.core)?;
+
         let mut system = BuildSystem::new(cfg, None, None).await?;
         system.build().await?;
         Ok(())

--- a/src/cmd/clean.rs
+++ b/src/cmd/clean.rs
@@ -8,6 +8,7 @@ use tokio::process::Command;
 use crate::common::remove_dir_all;
 use crate::config::{ConfigOpts, ConfigOptsClean};
 use crate::tools::cache_dir;
+use crate::version::enforce_version;
 
 /// Clean output artifacts.
 #[derive(Args)]
@@ -27,6 +28,8 @@ impl Clean {
     #[tracing::instrument(level = "trace", skip(self, config))]
     pub async fn run(self, config: Option<PathBuf>) -> Result<()> {
         let cfg = ConfigOpts::rtc_clean(self.clean, config)?;
+        enforce_version(&cfg.core)?;
+
         let _ = remove_dir_all(cfg.dist.clone()).await;
         if cfg.cargo {
             tracing::debug!("cleaning cargo dir");

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -6,6 +6,7 @@ use tokio::sync::broadcast;
 
 use crate::config::{ConfigOpts, ConfigOptsBuild, ConfigOptsServe, ConfigOptsWatch};
 use crate::serve::ServeSystem;
+use crate::version::enforce_version;
 
 /// Build, watch & serve the Rust WASM app and all of its assets.
 #[derive(Args)]
@@ -24,6 +25,8 @@ impl Serve {
     pub async fn run(self, config: Option<PathBuf>) -> Result<()> {
         let (shutdown_tx, _) = broadcast::channel(1);
         let cfg = ConfigOpts::rtc_serve(self.build, self.watch, self.serve, config).await?;
+        enforce_version(&cfg.watch.build.core)?;
+
         let system = ServeSystem::new(cfg, shutdown_tx.clone()).await?;
 
         let system_handle = tokio::spawn(system.run());

--- a/src/cmd/watch.rs
+++ b/src/cmd/watch.rs
@@ -5,6 +5,7 @@ use clap::Args;
 use tokio::sync::broadcast;
 
 use crate::config::{ConfigOpts, ConfigOptsBuild, ConfigOptsWatch};
+use crate::version::enforce_version;
 use crate::watch::WatchSystem;
 
 /// Build & watch the Rust WASM app and all of its assets.
@@ -22,6 +23,8 @@ impl Watch {
     pub async fn run(self, config: Option<PathBuf>) -> Result<()> {
         let (shutdown_tx, _shutdown_rx) = broadcast::channel(1);
         let cfg = ConfigOpts::rtc_watch(self.build, self.watch, config)?;
+        enforce_version(&cfg.build.core)?;
+
         let mut system = WatchSystem::new(cfg, shutdown_tx.clone(), None, None).await?;
 
         system.build().await.ok();

--- a/src/common.rs
+++ b/src/common.rs
@@ -21,6 +21,7 @@ pub static SERVER: Emoji = Emoji("📡 ", "");
 pub static LOCAL: Emoji = Emoji("🏠 ", "");
 pub static NETWORK: Emoji = Emoji("💻 ", "");
 pub static STARTING: Emoji = Emoji("🚀 ", "");
+pub static UPDATE: Emoji = Emoji("⏫ ", "");
 
 static CWD: Lazy<PathBuf> =
     Lazy::new(|| std::env::current_dir().expect("error getting current dir"));

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -16,7 +16,7 @@ pub const STAGE_DIR: &str = ".stage";
 
 pub use manifest::CargoMetadata;
 pub use models::{
-    ConfigOpts, ConfigOptsBuild, ConfigOptsClean, ConfigOptsHook, ConfigOptsProxy, ConfigOptsServe,
-    ConfigOptsTools, ConfigOptsWatch, CrossOrigin, WsProtocol,
+    ConfigOpts, ConfigOptsBuild, ConfigOptsClean, ConfigOptsCore, ConfigOptsHook, ConfigOptsProxy,
+    ConfigOptsServe, ConfigOptsTools, ConfigOptsWatch, CrossOrigin, WsProtocol,
 };
-pub use rt::{Features, RtcBuild, RtcClean, RtcServe, RtcWatch};
+pub use rt::{Features, RtcBuild, RtcClean, RtcCore, RtcServe, RtcWatch};

--- a/src/config/models/test.rs
+++ b/src/config/models/test.rs
@@ -64,7 +64,7 @@ fn assert_trunk_version(
         assert!(
             crate::version::enforce_version_with(
                 &cfg.core.trunk_version,
-                Version::parse(version).unwrap()
+                Version::parse(version).expect("version must parse")
             )
             .is_ok(),
             "Version should pass: {version}"
@@ -75,7 +75,7 @@ fn assert_trunk_version(
         assert!(
             crate::version::enforce_version_with(
                 &cfg.core.trunk_version,
-                Version::parse(version).unwrap()
+                Version::parse(version).expect("version must parse")
             )
             .is_err(),
             "Version should fail: {version}"
@@ -158,7 +158,7 @@ fn trunk_version_prerelease() {
                 major: 0,
                 minor: Some(19),
                 patch: Some(0),
-                pre: Prerelease::new("alpha.1").unwrap(),
+                pre: Prerelease::new("alpha.1").expect("prerelease must parse"),
             }],
         },
         [
@@ -174,16 +174,17 @@ fn trunk_version_prerelease() {
 /// Ensure that we can load the example config
 #[test]
 fn example_config() {
-    let dir = tempdir().unwrap();
+    let dir = tempdir().expect("should be able to create temp directory");
 
     let cwd = std::env::current_dir().expect("error getting cwd");
     let path = cwd.join("Trunk.toml");
     let target = dir.path().join("Trunk.toml");
 
     // copy to temp dir
-    fs::copy(&path, &target).unwrap();
+    fs::copy(path, &target).expect("should copy file");
     // create a dummy index.html
-    fs::write(dir.path().join("index.html"), r#""#).unwrap();
+    fs::write(dir.path().join("index.html"), r#""#)
+        .expect("should be able to write temporary file");
 
     // check
     ConfigOpts::file_and_env_layers(Some(target)).expect("example config should be parsable");

--- a/src/config/models/test.rs
+++ b/src/config/models/test.rs
@@ -1,6 +1,8 @@
 use crate::config::models::*;
 use semver::{Comparator, Op, Prerelease, Version};
+use std::fs;
 use std::path::Path;
+use tempfile::tempdir;
 
 #[cfg(not(target_family = "windows"))]
 #[test]
@@ -167,4 +169,22 @@ fn trunk_version_prerelease() {
         ],
         ["0.18.0", "0.18.0-alpha.1"],
     )
+}
+
+/// Ensure that we can load the example config
+#[test]
+fn example_config() {
+    let dir = tempdir().unwrap();
+
+    let cwd = std::env::current_dir().expect("error getting cwd");
+    let path = cwd.join("Trunk.toml");
+    let target = dir.path().join("Trunk.toml");
+
+    // copy to temp dir
+    fs::copy(&path, &target).unwrap();
+    // create a dummy index.html
+    fs::write(dir.path().join("index.html"), r#""#).unwrap();
+
+    // check
+    ConfigOpts::file_and_env_layers(Some(target)).expect("example config should be parsable");
 }

--- a/src/config/rt/clean.rs
+++ b/src/config/rt/clean.rs
@@ -1,10 +1,12 @@
 use super::super::DIST_DIR;
-use crate::config::ConfigOptsClean;
+use crate::config::{ConfigOptsClean, ConfigOptsCore, RtcCore};
 use std::path::PathBuf;
+use std::sync::Arc;
 
 /// Runtime config for the clean system.
 #[derive(Clone, Debug)]
 pub struct RtcClean {
+    pub core: Arc<RtcCore>,
     /// The output dir for all final assets.
     pub dist: PathBuf,
     /// Optionally perform a cargo clean.
@@ -12,8 +14,11 @@ pub struct RtcClean {
 }
 
 impl RtcClean {
-    pub(crate) fn new(opts: ConfigOptsClean) -> Self {
+    pub(crate) fn new(core: ConfigOptsCore, opts: ConfigOptsClean) -> Self {
+        let core = Arc::new(RtcCore::new(core));
+
         Self {
+            core,
             dist: opts.dist.unwrap_or_else(|| DIST_DIR.into()),
             cargo: opts.cargo,
         }

--- a/src/config/rt/mod.rs
+++ b/src/config/rt/mod.rs
@@ -7,3 +7,28 @@ pub use build::*;
 pub use clean::*;
 pub use serve::*;
 pub use watch::*;
+
+use crate::config::models::ConfigOptsCore;
+use semver::VersionReq;
+
+/// Runtime config for the core project.
+#[derive(Clone, Debug)]
+pub struct RtcCore {
+    pub trunk_version: VersionReq,
+}
+
+impl RtcCore {
+    pub(super) fn new(opts: ConfigOptsCore) -> Self {
+        let ConfigOptsCore { trunk_version } = opts;
+        Self {
+            trunk_version: trunk_version.unwrap_or_default(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn new_test() -> Self {
+        RtcCore {
+            trunk_version: VersionReq::STAR,
+        }
+    }
+}

--- a/src/config/rt/serve.rs
+++ b/src/config/rt/serve.rs
@@ -1,7 +1,7 @@
 use crate::config::models::AddressFamily;
 use crate::config::{
-    ConfigOptsBuild, ConfigOptsHook, ConfigOptsProxy, ConfigOptsServe, ConfigOptsTools,
-    ConfigOptsWatch, WsProtocol,
+    ConfigOptsBuild, ConfigOptsCore, ConfigOptsHook, ConfigOptsProxy, ConfigOptsServe,
+    ConfigOptsTools, ConfigOptsWatch, WsProtocol,
 };
 use anyhow::{anyhow, Context};
 use axum::http::Uri;
@@ -50,6 +50,7 @@ pub struct RtcServe {
 
 impl RtcServe {
     pub(crate) async fn new(
+        core_opts: ConfigOptsCore,
         build_opts: ConfigOptsBuild,
         watch_opts: ConfigOptsWatch,
         opts: ConfigOptsServe,
@@ -58,6 +59,7 @@ impl RtcServe {
         proxies: Option<Vec<ConfigOptsProxy>>,
     ) -> anyhow::Result<Self> {
         let watch = Arc::new(super::RtcWatch::new(
+            core_opts,
             build_opts,
             watch_opts,
             tools,

--- a/src/config/rt/serve.rs
+++ b/src/config/rt/serve.rs
@@ -72,9 +72,16 @@ impl RtcServe {
             absolute_path_if_some(opts.tls_cert_path, "tls_cert_path")?,
         )
         .await?;
+
+        let addresses = opts
+            .address
+            .into_iter()
+            .chain(opts.addresses.into_iter().flatten())
+            .collect::<Vec<_>>();
+
         Ok(Self {
             watch,
-            addresses: build_address_list(opts.prefer_address_family, opts.address),
+            addresses: build_address_list(opts.prefer_address_family, addresses),
             port: opts.port.unwrap_or(8080),
             open: opts.open,
             proxy_backend: opts.proxy_backend,
@@ -92,11 +99,8 @@ impl RtcServe {
     }
 }
 
-fn build_address_list(
-    preference: Option<AddressFamily>,
-    addresses: Option<Vec<IpAddr>>,
-) -> Vec<IpAddr> {
-    if let Some(addresses) = addresses {
+fn build_address_list(preference: Option<AddressFamily>, addresses: Vec<IpAddr>) -> Vec<IpAddr> {
+    if !addresses.is_empty() {
         addresses
     } else {
         match list_afinet_netifas() {

--- a/src/config/rt/watch.rs
+++ b/src/config/rt/watch.rs
@@ -1,4 +1,6 @@
-use crate::config::{ConfigOptsBuild, ConfigOptsHook, ConfigOptsTools, ConfigOptsWatch};
+use crate::config::{
+    ConfigOptsBuild, ConfigOptsCore, ConfigOptsHook, ConfigOptsTools, ConfigOptsWatch,
+};
 use anyhow::anyhow;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -23,6 +25,7 @@ pub struct RtcWatch {
 
 impl RtcWatch {
     pub(crate) fn new(
+        core_opts: ConfigOptsCore,
         build_opts: ConfigOptsBuild,
         opts: ConfigOptsWatch,
         tools: ConfigOptsTools,
@@ -31,6 +34,7 @@ impl RtcWatch {
         no_error_reporting: bool,
     ) -> anyhow::Result<Self> {
         let build = Arc::new(super::RtcBuild::new(
+            core_opts,
             build_opts,
             tools,
             hooks,

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,6 @@ use common::STARTING;
 use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::process::ExitCode;
-use std::time::Duration;
 use tracing_subscriber::prelude::*;
 
 #[tokio::main]

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ use std::time::Duration;
 use tracing_subscriber::prelude::*;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<ExitCode> {
     let cli = Trunk::parse();
 
     let colored = std::io::stdout().is_terminal() && std::env::var_os("NO_COLOR").is_none();
@@ -58,7 +58,13 @@ async fn main() -> Result<()> {
         env!("CARGO_PKG_VERSION")
     );
 
-    cli.run().await
+    Ok(match cli.run().await {
+        Err(err) => {
+            tracing::error!("{err}");
+            ExitCode::FAILURE
+        }
+        Ok(()) => ExitCode::SUCCESS,
+    })
 }
 
 fn eval_logging(cli: &Trunk) -> tracing_subscriber::EnvFilter {

--- a/src/pipelines/copy_dir.rs
+++ b/src/pipelines/copy_dir.rs
@@ -65,7 +65,7 @@ impl CopyDir {
     #[tracing::instrument(level = "trace", skip(self))]
     async fn run(self) -> Result<TrunkAssetPipelineOutput> {
         let rel_path = crate::common::strip_prefix(&self.path);
-        tracing::info!(path = ?rel_path, "copying directory");
+        tracing::debug!(path = ?rel_path, "copying directory");
 
         let canonical_path = fs::canonicalize(&self.path).await.with_context(|| {
             format!("error taking canonical path of directory {:?}", &self.path)
@@ -89,7 +89,7 @@ impl CopyDir {
         };
         copy_dir_recursive(canonical_path, dir_out).await?;
 
-        tracing::info!(path = ?rel_path, "finished copying directory");
+        tracing::debug!(path = ?rel_path, "finished copying directory");
         Ok(TrunkAssetPipelineOutput::CopyDir(CopyDirOutput(self.id)))
     }
 }

--- a/src/pipelines/copy_file.rs
+++ b/src/pipelines/copy_file.rs
@@ -49,12 +49,12 @@ impl CopyFile {
     #[tracing::instrument(level = "trace", skip(self))]
     async fn run(self) -> Result<TrunkAssetPipelineOutput> {
         let rel_path = crate::common::strip_prefix(&self.asset.path);
-        tracing::info!(path = ?rel_path, "copying file");
+        tracing::debug!(path = ?rel_path, "copying file");
         let _ = self
             .asset
             .copy(&self.cfg.staging_dist, false, false, AssetFileType::Other)
             .await?;
-        tracing::info!(path = ?rel_path, "finished copying file");
+        tracing::debug!(path = ?rel_path, "finished copying file");
         Ok(TrunkAssetPipelineOutput::CopyFile(CopyFileOutput(self.id)))
     }
 }

--- a/src/pipelines/css.rs
+++ b/src/pipelines/css.rs
@@ -69,7 +69,7 @@ impl Css {
     #[tracing::instrument(level = "trace", skip(self))]
     async fn run(self) -> Result<TrunkAssetPipelineOutput> {
         let rel_path = crate::common::strip_prefix(&self.asset.path);
-        tracing::info!(path = ?rel_path, "copying & hashing css");
+        tracing::debug!(path = ?rel_path, "copying & hashing css");
         let minify = self.cfg.release && self.minify && !self.cfg.no_minification;
         let file = self
             .asset
@@ -80,7 +80,7 @@ impl Css {
                 AssetFileType::Css,
             )
             .await?;
-        tracing::info!(path = ?rel_path, "finished copying & hashing css");
+        tracing::debug!(path = ?rel_path, "finished copying & hashing css");
 
         let result_file = self.cfg.staging_dist.join(&file);
         let integrity = OutputDigest::generate(self.integrity, || std::fs::read(&result_file))

--- a/src/pipelines/html.rs
+++ b/src/pipelines/html.rs
@@ -79,7 +79,7 @@ impl HtmlPipeline {
     /// Run this pipeline.
     #[tracing::instrument(level = "trace", skip(self))]
     async fn run(self: Arc<Self>) -> Result<()> {
-        tracing::info!("spawning asset pipelines");
+        tracing::debug!("spawning asset pipelines");
 
         // Spawn and wait on pre-build hooks.
         wait_hooks(spawn_hooks(self.cfg.clone(), PipelineStage::PreBuild)).await?;

--- a/src/pipelines/icon.rs
+++ b/src/pipelines/icon.rs
@@ -60,7 +60,7 @@ impl Icon {
     #[tracing::instrument(level = "trace", skip(self))]
     async fn run(self) -> Result<TrunkAssetPipelineOutput> {
         let rel_path = crate::common::strip_prefix(&self.asset.path);
-        tracing::info!(path = ?rel_path, "copying & hashing icon");
+        tracing::debug!(path = ?rel_path, "copying & hashing icon");
         let mime_type = mime_guess::from_path(&self.asset.path).first_or_octet_stream();
         let image_type = match mime_type.type_().as_str() {
             "image/png" => ImageType::Png,
@@ -85,7 +85,7 @@ impl Icon {
                 )
             })?;
 
-        tracing::info!(path = ?rel_path, "finished copying & hashing icon");
+        tracing::debug!(path = ?rel_path, "finished copying & hashing icon");
         Ok(TrunkAssetPipelineOutput::Icon(IconOutput {
             cfg: self.cfg.clone(),
             id: self.id,

--- a/src/pipelines/inline.rs
+++ b/src/pipelines/inline.rs
@@ -53,9 +53,9 @@ impl Inline {
     #[tracing::instrument(level = "trace", skip(self))]
     async fn run(self) -> Result<TrunkAssetPipelineOutput> {
         let rel_path = crate::common::strip_prefix(&self.asset.path);
-        tracing::info!(path = ?rel_path, "reading file content");
+        tracing::debug!(path = ?rel_path, "reading file content");
         let content = self.asset.read_to_string().await?;
-        tracing::info!(path = ?rel_path, "finished reading file content");
+        tracing::debug!(path = ?rel_path, "finished reading file content");
 
         Ok(TrunkAssetPipelineOutput::Inline(InlineOutput {
             id: self.id,

--- a/src/pipelines/js.rs
+++ b/src/pipelines/js.rs
@@ -70,7 +70,7 @@ impl Js {
     #[tracing::instrument(level = "trace", skip(self))]
     async fn run(self) -> Result<TrunkAssetPipelineOutput> {
         let rel_path = crate::common::strip_prefix(&self.asset.path);
-        tracing::info!(path = ?rel_path, "copying & hashing js");
+        tracing::debug!(path = ?rel_path, "copying & hashing js");
         let minify = self.cfg.release && self.minify && !self.cfg.no_minification;
         let file = self
             .asset
@@ -85,7 +85,7 @@ impl Js {
                 },
             )
             .await?;
-        tracing::info!(path = ?rel_path, "finished copying & hashing js");
+        tracing::debug!(path = ?rel_path, "finished copying & hashing js");
 
         let result_file = self.cfg.staging_dist.join(&file);
         let integrity = OutputDigest::generate(self.integrity, || std::fs::read(&result_file))

--- a/src/pipelines/rust/mod.rs
+++ b/src/pipelines/rust/mod.rs
@@ -323,13 +323,13 @@ impl RustApp {
             .context("finalizing digest")?;
 
         // now the build is complete
-        tracing::info!("rust build complete");
+        tracing::debug!("rust build complete");
         Ok(TrunkAssetPipelineOutput::RustApp(output))
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
     async fn cargo_build(&mut self) -> Result<PathBuf> {
-        tracing::info!("building {}", &self.manifest.package.name);
+        tracing::debug!("building {}", &self.manifest.package.name);
 
         // Spawn the cargo build process.
         let mut args = vec![
@@ -393,7 +393,7 @@ impl RustApp {
         build_res?;
 
         // Perform a final cargo invocation on success to get artifact names.
-        tracing::info!("fetching cargo artifacts");
+        tracing::debug!("fetching cargo artifacts");
         args.push("--message-format=json");
         let artifacts_out = Command::new("cargo")
             .args(args.as_slice())
@@ -504,7 +504,7 @@ impl RustApp {
         }
 
         // Invoke wasm-bindgen.
-        tracing::info!("calling wasm-bindgen for {}", self.name);
+        tracing::debug!("calling wasm-bindgen for {}", self.name);
         common::run_command(wasm_bindgen_name, &wasm_bindgen, &args)
             .await
             .map_err(|err| check_target_not_found_err(err, wasm_bindgen_name))?;
@@ -842,7 +842,7 @@ impl RustApp {
         }
 
         // Invoke wasm-opt.
-        tracing::info!("calling wasm-opt");
+        tracing::debug!("calling wasm-opt");
         common::run_command(wasm_opt_name, &wasm_opt, &args)
             .await
             .map_err(|err| check_target_not_found_err(err, wasm_opt_name))?;

--- a/src/pipelines/sass.rs
+++ b/src/pipelines/sass.rs
@@ -107,7 +107,7 @@ impl Sass {
         ];
 
         let rel_path = common::strip_prefix(&self.asset.path);
-        tracing::info!(path = ?rel_path, "compiling sass/scss");
+        tracing::debug!(path = ?rel_path, "compiling sass/scss");
         common::run_command(Application::Sass.name(), &sass, args).await?;
 
         let css = fs::read_to_string(&temp_target_file_path)
@@ -144,7 +144,7 @@ impl Sass {
             CssRef::File(file_name, integrity)
         };
 
-        tracing::info!(path = ?rel_path, "finished compiling sass/scss");
+        tracing::debug!(path = ?rel_path, "finished compiling sass/scss");
         Ok(TrunkAssetPipelineOutput::Sass(SassOutput {
             cfg: self.cfg.clone(),
             id: self.id,

--- a/src/pipelines/tailwind_css.rs
+++ b/src/pipelines/tailwind_css.rs
@@ -89,7 +89,7 @@ impl TailwindCss {
         let args = &["--input", &path_str, "--output", &file_path, style];
 
         let rel_path = crate::common::strip_prefix(&self.asset.path);
-        tracing::info!(path = ?rel_path, "compiling tailwind css");
+        tracing::debug!(path = ?rel_path, "compiling tailwind css");
         common::run_command(Application::TailwindCss.name(), &tailwind, args).await?;
 
         let css = fs::read_to_string(&file_path).await?;
@@ -121,7 +121,7 @@ impl TailwindCss {
             CssRef::File(file_name, integrity)
         };
 
-        tracing::info!(path = ?rel_path, "finished compiling tailwind css");
+        tracing::debug!(path = ?rel_path, "finished compiling tailwind css");
         Ok(TrunkAssetPipelineOutput::TailwindCss(TailwindCssOutput {
             cfg: self.cfg.clone(),
             id: self.id,

--- a/src/version/check.rs
+++ b/src/version/check.rs
@@ -1,0 +1,28 @@
+use super::{NAME, VERSION};
+use crate::version::state::Versions;
+use semver::Version;
+use std::time::Duration;
+
+pub async fn most_recent() -> anyhow::Result<Versions> {
+    tracing::debug!("Checking for updates");
+
+    let client =
+        crates_io_api::AsyncClient::new(&format!("{NAME}/{VERSION}"), Duration::from_secs(1))?;
+    let response = client.get_crate(NAME).await?;
+
+    let versions = response
+        .versions
+        .into_iter()
+        .filter(|v| !v.yanked)
+        .map(|v| v.num)
+        .filter_map(|v| Version::parse(&v).ok())
+        .collect::<Vec<_>>();
+
+    let release = versions.iter().filter(|v| v.pre.is_empty()).max().cloned();
+    let prerelease = versions.iter().max().cloned();
+
+    Ok(Versions {
+        release,
+        prerelease,
+    })
+}

--- a/src/version/enforce.rs
+++ b/src/version/enforce.rs
@@ -1,0 +1,36 @@
+use crate::config::RtcCore;
+use crate::version::VERSION;
+use anyhow::bail;
+use semver::{Version, VersionReq};
+
+/// Ensure that we are the right trunk version for the project
+pub(crate) fn enforce_version(core: &RtcCore) -> anyhow::Result<()> {
+    let actual = match Version::parse(VERSION) {
+        Err(err) => {
+            tracing::warn!("Unable to parse trunk version, skipping version check: {err}");
+            return Ok(());
+        }
+        Ok(version) => version,
+    };
+
+    enforce_version_with(&core.trunk_version, actual)
+}
+
+/// Ensure that we are the right trunk version for the project
+pub(crate) fn enforce_version_with(required: &VersionReq, actual: Version) -> anyhow::Result<()> {
+    tracing::debug!("Enforce version - actual: {actual}, required: {required}");
+
+    if required == &VersionReq::STAR {
+        // this should match, but does not match any pre-release version. Which we still accept in this case.
+        return Ok(());
+    }
+
+    let outcome = required.matches(&actual);
+    tracing::debug!("Current version: {actual}, required version: {required}, matches: {outcome}");
+
+    if !outcome {
+        bail!("Project requires a trunk version of '{required}', the current trunk version is: '{actual}'");
+    }
+
+    Ok(())
+}

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -1,0 +1,84 @@
+mod check;
+mod enforce;
+mod state;
+
+#[cfg(test)]
+pub(crate) use enforce::enforce_version_with;
+
+pub(crate) use enforce::enforce_version;
+
+use crate::common::UPDATE;
+use crate::version::state::{State, Versions};
+use semver::Version;
+use std::thread;
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+const NAME: &str = env!("CARGO_PKG_NAME");
+
+#[cfg(feature = "update_check")]
+pub fn update_check(skip: bool) {
+    if skip {
+        return;
+    }
+
+    tracing::debug!("Spawning update check");
+
+    // We need to spawn this in a dedicated tokio runtime, as otherwise this would block
+    // the current tokio runtime from existing. There seems to be an issue with where even
+    // with an aborted spawned task, tokio will wait for it to end indefinitely.
+    thread::spawn(|| {
+        perform_update_check();
+    });
+}
+
+#[cfg(not(feature = "update_check"))]
+pub fn update_check(_: bool) {}
+
+/// Check if there's a newer version available
+#[tokio::main]
+async fn perform_update_check() {
+    tracing::debug!("Performing update check");
+
+    let versions = match state::need_check().await {
+        State::NotNeeded(versions) => {
+            tracing::debug!("No refresh needed");
+            versions
+        }
+        State::Needed => match check::most_recent().await {
+            Err(err) => {
+                tracing::debug!("Failed to check for new version: {err}");
+                return;
+            }
+            Ok(versions) => {
+                tracing::debug!("New versions: {versions:?}");
+                state::record_checked(versions.clone()).await;
+                versions
+            }
+        },
+    };
+
+    announce_version(&versions);
+}
+
+/// Announce a new version if it is newer than our current
+fn announce_version(versions: &Versions) {
+    let Ok(current) = Version::parse(VERSION) else {
+        tracing::debug!("Failed to parse current version ({VERSION})");
+        return;
+    };
+
+    let most_recent = match current.pre.is_empty() {
+        false => &versions.prerelease,
+        true => &versions.release,
+    };
+
+    let Some(most_recent) = most_recent else {
+        return;
+    };
+
+    tracing::debug!("Current: {current}, Most recent: {most_recent}");
+
+    if most_recent > &current {
+        tracing::info!("{UPDATE}Found an update of {NAME}: {VERSION} -> {most_recent}");
+    }
+}

--- a/src/version/state.rs
+++ b/src/version/state.rs
@@ -1,0 +1,115 @@
+use semver::Version;
+use serde::{Deserialize, Serialize};
+use std::io::ErrorKind;
+use std::path::PathBuf;
+use time::{Duration, OffsetDateTime};
+
+const CHECK_PERIOD: Duration = Duration::days(1);
+
+/// Get the path to the state file.
+fn state_file() -> Option<PathBuf> {
+    let dirs = directories::BaseDirs::new()?;
+    let path = dirs.state_dir().unwrap_or_else(|| dirs.data_local_dir());
+
+    Some(path.join(env!("CARGO_PKG_NAME")).join("update.json"))
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct StateInformation {
+    #[serde(with = "time::serde::rfc3339")]
+    pub last_check: OffsetDateTime,
+
+    pub versions: Versions,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Versions {
+    /// The most recent released version
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub release: Option<Version>,
+
+    /// The most recent version, including pre-releases
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prerelease: Option<Version>,
+}
+
+#[derive(Clone, Debug)]
+pub enum State {
+    NotNeeded(Versions),
+    Needed,
+}
+
+/// Evaluate if we are due for a check
+///
+/// Returns `false` if anything goes wrong.
+pub async fn need_check() -> State {
+    let Some(file) = state_file() else {
+        tracing::debug!("Unable to find a user home. Skipping update checks.");
+        return State::NotNeeded(Default::default());
+    };
+
+    let state = match tokio::fs::read(&file).await {
+        Err(err) if err.kind() == ErrorKind::NotFound => return State::Needed,
+        Err(err) => {
+            tracing::debug!(
+                "Failed to check update state file ({}), skipping: {err}",
+                file.display()
+            );
+            return State::NotNeeded(Default::default());
+        }
+        Ok(state) => state,
+    };
+
+    let Ok(state) = serde_json::from_slice::<StateInformation>(&state) else {
+        // if we can't read the file, check and re-write
+        return State::Needed;
+    };
+
+    let diff = OffsetDateTime::now_utc() - state.last_check;
+
+    tracing::debug!("Time since last check: {diff}");
+
+    if diff > CHECK_PERIOD {
+        State::Needed
+    } else {
+        State::NotNeeded(state.versions)
+    }
+}
+
+/// Record that we did perform a check.
+///
+/// Silently ignores errors.
+pub async fn record_checked(versions: Versions) {
+    let Some(file) = state_file() else {
+        tracing::debug!("Unable to find a user home. Skipping update checks.");
+        return;
+    };
+
+    let state = match serde_json::to_vec(&StateInformation {
+        last_check: OffsetDateTime::now_utc(),
+        versions,
+    }) {
+        Ok(state) => state,
+        Err(err) => {
+            tracing::debug!("Unable to serialize state file: {err}");
+            return;
+        }
+    };
+
+    if let Some(parent) = file.parent() {
+        if let Err(err) = tokio::fs::create_dir_all(parent).await {
+            tracing::debug!(
+                "Failed to create parent directory for update state ({}): {err}",
+                parent.display()
+            );
+            return;
+        }
+    }
+
+    if let Err(err) = tokio::fs::write(&file, state).await {
+        tracing::debug!(
+            "Failed to write update state file ({}): {err}",
+            file.display()
+        );
+    }
+}

--- a/tests/data/trunk-version-any.toml
+++ b/tests/data/trunk-version-any.toml
@@ -1,0 +1,4 @@
+trunk-version = "*"
+
+[build]
+target = "../../examples/yew/index.html"

--- a/tests/data/trunk-version-minor.toml
+++ b/tests/data/trunk-version-minor.toml
@@ -1,0 +1,4 @@
+trunk-version = "0.19"
+
+[build]
+target = "../../examples/yew/index.html"

--- a/tests/data/trunk-version-none.toml
+++ b/tests/data/trunk-version-none.toml
@@ -1,0 +1,2 @@
+[build]
+target = "../../examples/yew/index.html"

--- a/tests/data/trunk-version-prerelease.toml
+++ b/tests/data/trunk-version-prerelease.toml
@@ -1,5 +1,4 @@
 trunk-version = "0.19.0-alpha.1"
 
 [build]
-target = "index.html"
-dist = "dist"
+target = "../../examples/yew/index.html"

--- a/tests/data/trunk-version-range.toml
+++ b/tests/data/trunk-version-range.toml
@@ -1,0 +1,4 @@
+trunk-version = ">=0.17, <0.19"
+
+[build]
+target = "../../examples/yew/index.html"


### PR DESCRIPTION
This PR makes trunk aware of its version. Enabling two features with that:

1. Allow enforcing a trunk version for a project. This allows one to require a certain trunk version for a project, e.g. in the case user newer features from trunk.
2. Implement an "update check", so that trunk can let you know that there's a newer version available.

The update check can be disabled by disabling the feature `update_check`. This might be useful for packagers, like nix and homebrew.