### PR TITLE
Use relative url for resources

### DIFF
--- a/src/autoreload.js
+++ b/src/autoreload.js
@@ -10,7 +10,8 @@
             : window.location.protocol === 'https:'
                 ? 'wss'
                 : 'ws';
-    const url = protocol + '://' + address + '/_trunk/ws';
+    const pathname = window.location.pathname.slice(0, window.location.pathname.lastIndexOf('/'));
+    const url = protocol + '://' + address + pathname + '/_trunk/ws';
 
     class Overlay {
         constructor() {
@@ -43,7 +44,7 @@
             this._message = document.createElement("div");
             this._message.style.whiteSpace = "pre-wrap";
 
-            const icon= document.createElement("div");
+            const icon = document.createElement("div");
             icon.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" fill="#dc3545" viewBox="0 0 16 16"><path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5zm.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/></svg>';
             this._title.prepend(icon);
 
@@ -110,7 +111,7 @@
             window.location.reload();
         }
 
-        buildFailure({reason}) {
+        buildFailure({ reason }) {
             // also log the console
             console.error("Build failed:", reason);
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -4,7 +4,6 @@ use async_recursion::async_recursion;
 use console::Emoji;
 use once_cell::sync::Lazy;
 use std::collections::HashSet;
-use std::convert::Infallible;
 use std::ffi::OsStr;
 use std::fmt::Debug;
 use std::fs::Metadata;
@@ -25,17 +24,6 @@ pub static UPDATE: Emoji = Emoji("⏫ ", "");
 
 static CWD: Lazy<PathBuf> =
     Lazy::new(|| std::env::current_dir().expect("error getting current dir"));
-
-/// Ensure the given value for `--public-url` is formatted correctly.
-pub fn parse_public_url(val: &str) -> Result<String, Infallible> {
-    let prefix = if val.starts_with('/') || val.starts_with("./") {
-        ""
-    } else {
-        "/"
-    };
-    let suffix = if !val.ends_with('/') { "/" } else { "" };
-    Ok(format!("{}{}{}", prefix, val, suffix))
-}
 
 /// A utility function to recursively copy a directory.
 #[async_recursion]

--- a/src/config/models/build.rs
+++ b/src/config/models/build.rs
@@ -1,4 +1,3 @@
-use crate::common::parse_public_url;
 use clap::Args;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -36,7 +35,8 @@ pub struct ConfigOptsBuild {
     pub locked: bool,
 
     /// The public URL from which assets are to be served
-    #[arg(long, value_parser = parse_public_url)]
+    #[arg(long)]
+    #[serde(default)]
     pub public_url: Option<String>,
 
     /// Build without default features [default: false]

--- a/src/pipelines/css.rs
+++ b/src/pipelines/css.rs
@@ -120,11 +120,15 @@ impl CssOutput {
         let mut attrs = self.other_attrs.clone();
 
         self.integrity.insert_into(&mut attrs);
-
+        let base = &self.cfg.public_url;
+        let base = if base.is_empty() || base == "/" {
+            "./".to_owned()
+        } else {
+            base.clone()
+        };
         dom.select(&super::trunk_id_selector(self.id))
             .replace_with_html(format!(
                 r#"<link rel="stylesheet" href="{base}{file}"{attrs}/>"#,
-                base = &self.cfg.public_url,
                 file = self.file,
                 attrs = AttrWriter::new(&attrs, AttrWriter::EXCLUDE_CSS_LINK),
             ));

--- a/src/pipelines/rust/output.rs
+++ b/src/pipelines/rust/output.rs
@@ -96,12 +96,12 @@ impl RustAppOutput {
             self.integrities
                 .clone()
                 .build()
-                .inject(dom.select(head), base, self.cross_origin);
+                .inject(dom.select(head), &base, self.cross_origin);
         }
 
         let script = match pattern_script {
             Some(pattern) => pattern_evaluate(pattern, &params),
-            None => self.default_initializer(base, js, wasm),
+            None => self.default_initializer(&base, js, wasm),
         };
 
         match self.id {

--- a/src/pipelines/rust/output.rs
+++ b/src/pipelines/rust/output.rs
@@ -79,6 +79,11 @@ impl RustAppOutput {
             Some(x) => x.clone(),
             None => HashMap::new(),
         };
+        let base = if base.is_empty() || base == "/" {
+            "./".to_owned()
+        } else {
+            base.clone()
+        };
         params.insert("base".to_owned(), base.clone());
         params.insert("js".to_owned(), js.clone());
         params.insert("wasm".to_owned(), wasm.clone());


### PR DESCRIPTION
This is a "work in progress" PR trying to address https://github.com/trunk-rs/trunk/issues/626 and https://github.com/trunk-rs/trunk/issues/668

I have not gone through all the different resources trunk bundles so I've likely missed something.

In summary, this PR will make base url default to "./" if it was empty or "/".
This results in resources being loaded relative to whichever original resource was requested. 
For example browser loads html, html refers to js/css/wasm, the browser tries loading the js/css/wasm from the same current path.
https://server.som/some_path/and_some_more/index.html refers to ./something.js and ./app.wasm which loads
https://server.som/some_path/and_some_more/something.js
https://server.som/some_path/and_some_more/app.wasm

Without this change:
https://server.som/some_path/and_some_more/index.html refers to /something.js and /app.wasm which loads
https://server.som/something.js
https://server.som/app.wasm
which does not work.

Similar thing for the _trunk/ws route for the reloading websocket.

