### PR TITLE
Fix --enable-cooldown option not working

### DIFF
--- a/src/watch.rs
+++ b/src/watch.rs
@@ -213,7 +213,9 @@ impl WatchSystem {
         tracing::debug!("Changes since last build was started, checking cooldown");
 
         if let Some(cooldown) = self.watcher_cooldown {
-            let time_since_last_build = self.last_change.saturating_duration_since(self.last_build_finished);
+            let time_since_last_build = self
+                .last_change
+                .saturating_duration_since(self.last_build_finished);
             if time_since_last_build < cooldown {
                 tracing::debug!(
                     "Cooldown still active: {} remaining",

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -213,7 +213,7 @@ impl WatchSystem {
         tracing::debug!("Changes since last build was started, checking cooldown");
 
         if let Some(cooldown) = self.watcher_cooldown {
-            let time_since_last_build = self.last_build_finished - self.last_change;
+            let time_since_last_build = self.last_change.saturating_duration_since(self.last_build_finished);
             if time_since_last_build < cooldown {
                 tracing::debug!(
                     "Cooldown still active: {} remaining",


### PR DESCRIPTION
Currently if I use `trunk serve --enable-cooldown` it doesn't trigger any build.
This PR fixes the `Instant`s being subtracted in the wrong order when using `--enable-cooldown` flag.

Also helps with #735 