### PR TITLE
Embed sass source-maps in non-release builds

### DIFF
--- a/src/pipelines/sass.rs
+++ b/src/pipelines/sass.rs
@@ -103,13 +103,19 @@ impl Sass {
                 .display()
                 .to_string();
 
-        let args = &[
-            "--no-source-map",
-            "--style",
-            match self.cfg.release && !self.cfg.no_minification {
-                true => "compressed",
-                false => "expanded",
+        let (no_source_map, expanded_style) = ("---no-source-map", "expanded");
+        let (source_map, output_style) = match self.cfg.release {
+            true => match self.cfg.no_minification {
+                true => (no_source_map, expanded_style),
+                false => (no_source_map, "compressed"),
             },
+            false => ("--embed-source-map", expanded_style),
+        };
+
+        let args = &[
+            source_map,
+            "--style",
+            output_style,
             &source_path_str,
             &temp_target_file_path,
         ];


### PR DESCRIPTION
Embedding sass source-maps in non-release builds would significantly improve development experience. This solves #528.

No extra files will be generated https://sass-lang.com/documentation/cli/dart-sass/#embed-source-map