### PR TITLE
perf: Remove unnecessary clone on target_html when minification isn't being performed.

### DIFF
--- a/src/pipelines/html.rs
+++ b/src/pipelines/html.rs
@@ -178,7 +178,7 @@ impl HtmlPipeline {
         // Assemble a new output index.html file.
         let output_html = match self.cfg.release && !self.cfg.no_minification {
             true => minify_html(target_html.0.as_slice()),
-            false => target_html.0.clone(),
+            false => target_html.0,
         };
 
         fs::write(self.cfg.staging_dist.join("index.html"), &output_html)


### PR DESCRIPTION
Removes an unnecessary clone on the HTML content, whilst minification isn't being performed.

The clone was not needed when `nipper` was still being used, but it became much more obvious when it was replaced by `lol_html`.

