### PR TITLE
fix: make manually inserted script tag, spec compliant.

### DIFF
--- a/site/content/assets.md
+++ b/site/content/assets.md
@@ -107,7 +107,7 @@ Classic script assets processed by Trunk must follow these three rules:
  - Must have the attribute `data-trunk`.
  - Must have the attribute `src`, pointing to a script file
 
-This will typically look like: `<script data-trunk src="{path}" ..other options here.. />`. All `<script data-trunk .../>` HTML elements will be replaced with the output HTML of the associated pipeline.
+This will typically look like: `<script data-trunk src="{path}" ..other options here..></script>`. All `<script data-trunk ...></script>` HTML elements will be replaced with the output HTML of the associated pipeline.
 
 Trunk will copy script files found in the source HTML without content modification. This content is hashed for cache control. The `src` attribute must be included in the script pointing to the script file to be processed.
 

--- a/src/pipelines/js.rs
+++ b/src/pipelines/js.rs
@@ -45,7 +45,7 @@ impl Js {
         // Build the path to the target asset.
         let src_attr = attrs
             .get(ATTR_SRC)
-            .context(r#"required attr `src` missing for <script data-trunk .../> element"#)?;
+            .context(r#"required attr `src` missing for <script data-trunk ...> element"#)?;
         let mut path = PathBuf::new();
         path.extend(src_attr.split('/'));
         let asset = AssetFile::new(&html_dir, path).await?;

--- a/src/pipelines/js.rs
+++ b/src/pipelines/js.rs
@@ -134,13 +134,13 @@ pub struct JsOutput {
 
 impl JsOutput {
     pub async fn finalize(self, dom: &mut Document) -> Result<()> {
-        let mut attrs = self.attrs.clone();
+        let mut attrs = self.attrs;
         self.integrity.insert_into(&mut attrs);
 
         dom.replace_with_html(
             &super::trunk_script_id_selector(self.id),
             &format!(
-                r#"<script src="{base}{file}"{attrs}/>"#,
+                r#"<script src="{base}{file}"{attrs}></script>"#,
                 attrs = AttrWriter::new(&attrs, AttrWriter::EXCLUDE_SCRIPT),
                 base = &self.cfg.public_url,
                 file = self.file

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -457,6 +457,8 @@ impl Document {
         })
     }
 
+    /// When manually inserting any HTML into the document, the inserted HTML must be HTML
+    /// compliant. Otherwise the change is ignored.
     fn replace_with_html(&mut self, selector: &str, html: &str) -> Result<()> {
         self.select_mut(selector, |el| {
             el.replace(html, lol_html::html_content::ContentType::Html);

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -450,6 +450,7 @@ impl Document {
         Ok(())
     }
 
+    /// Will silently fail when attempting to append to [Void Element](https://developer.mozilla.org/en-US/docs/Glossary/Void_element).
     fn append_html(&mut self, selector: &str, html: &str) -> Result<()> {
         self.select_mut(selector, |el| {
             el.append(html, lol_html::html_content::ContentType::Html);

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -457,8 +457,6 @@ impl Document {
         })
     }
 
-    /// When manually inserting any HTML into the document, the inserted HTML must be HTML
-    /// compliant. Otherwise the change is ignored.
     fn replace_with_html(&mut self, selector: &str, html: &str) -> Result<()> {
         self.select_mut(selector, |el| {
             el.replace(html, lol_html::html_content::ContentType::Html);


### PR DESCRIPTION
According to the [HTML spec](https://html.spec.whatwg.org/multipage/scripting.html) for the script tag "Neither tag is omissible." this means we must use opening and closing tags. While using `nipper` this mistake was silently corrected, so this is only coming up now. 

The behaviour of `lol_html`'s rewriter, is HTML spec compliant. Script tags that are inserted after an element without a closing tag, are not detected by `lol_html`. Meaning any modifications that are made, don't actually get applied.

All of the examples in the repository are spec compliant with the HTML script tag, however the example script tags in [trunk.rs](https://trunkrs.dev/assets/#script-assets) are considered invalid by `lol_html`, and incorrect by the HTML spec. The script tags on the site should also be corrected.

This fixes the issues mentioned in: https://github.com/trunk-rs/trunk/issues/742#issuecomment-2016316971
