### PR TITLE
chore: Remove `http-body` crate from dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3528,7 +3528,6 @@ dependencies = [
  "flate2",
  "futures-util",
  "htmlescape",
- "http-body",
  "humantime",
  "humantime-serde",
  "hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ envy = "0.4"
 flate2 = "1"
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
 htmlescape = "0.3.1"
-http-body = "0.4"
 humantime = "2"
 humantime-serde = "1"
 hyper = "0.14"

--- a/src/config/models/mod.rs
+++ b/src/config/models/mod.rs
@@ -2,7 +2,6 @@ use crate::config::{RtcBuild, RtcClean, RtcServe, RtcWatch};
 use anyhow::{Context, Result};
 use axum::http::Uri;
 use clap::ValueEnum;
-use humantime_serde::re::humantime;
 use serde::{Deserialize, Deserializer};
 use std::fmt::{Display, Formatter};
 use std::path::PathBuf;

--- a/src/pipelines/css.rs
+++ b/src/pipelines/css.rs
@@ -51,7 +51,7 @@ impl Css {
         let asset = AssetFile::new(&html_dir, path).await?;
 
         let integrity = IntegrityType::from_attrs(&attrs, &cfg)?;
-        let minify = attrs.get(ATTR_MINIFY).is_none();
+        let minify = !attrs.contains_key(ATTR_MINIFY);
         let target_path = data_target_path(&attrs)?;
 
         Ok(Self {

--- a/src/pipelines/js.rs
+++ b/src/pipelines/js.rs
@@ -52,7 +52,7 @@ impl Js {
 
         let integrity = IntegrityType::from_attrs(&attrs, &cfg)?;
         let module = attrs.get("type").map(|s| s.as_str()) == Some("module");
-        let minify = attrs.get(ATTR_MINIFY).is_none();
+        let minify = !attrs.contains_key(ATTR_MINIFY);
         let target_path = data_target_path(&attrs)?;
 
         Ok(Self {

--- a/src/pipelines/rust/mod.rs
+++ b/src/pipelines/rust/mod.rs
@@ -219,7 +219,7 @@ impl RustApp {
 
         // bindings
 
-        let import_bindings = attrs.get("data-wasm-no-import").is_none();
+        let import_bindings = !attrs.contains_key("data-wasm-no-import");
         let import_bindings_name = attrs.get("data-wasm-import-name").cloned();
 
         // progress function

--- a/src/pipelines/rust/mod.rs
+++ b/src/pipelines/rust/mod.rs
@@ -28,7 +28,6 @@ use minify_js::TopLevelMode;
 use seahash::SeaHasher;
 use std::collections::HashSet;
 use std::hash::Hasher;
-use std::iter::Iterator;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::str::FromStr;

--- a/src/pipelines/sass.rs
+++ b/src/pipelines/sass.rs
@@ -52,7 +52,7 @@ impl Sass {
         let mut path = PathBuf::new();
         path.extend(href_attr.split('/'));
         let asset = AssetFile::new(&html_dir, path).await?;
-        let use_inline = attrs.get(ATTR_INLINE).is_some();
+        let use_inline = attrs.contains_key(ATTR_INLINE);
 
         let integrity = IntegrityType::from_attrs(&attrs, &cfg)?;
         let target_path = data_target_path(&attrs)?;

--- a/src/pipelines/tailwind_css.rs
+++ b/src/pipelines/tailwind_css.rs
@@ -49,7 +49,7 @@ impl TailwindCss {
         let mut path = PathBuf::new();
         path.extend(href_attr.split('/'));
         let asset = AssetFile::new(&html_dir, path).await?;
-        let use_inline = attrs.get(ATTR_INLINE).is_some();
+        let use_inline = attrs.contains_key(ATTR_INLINE);
 
         let integrity = IntegrityType::from_attrs(&attrs, &cfg)?;
         let target_path = data_target_path(&attrs)?;

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -668,7 +668,7 @@ mod archive {
 
 #[cfg(test)]
 mod tests {
-    use anyhow::{ensure, Context, Result};
+    use anyhow::ensure;
 
     use super::*;
 


### PR DESCRIPTION
`trunk` doesn't use http-body crate.  
I think `trunk` should remove `http-body` rather than update it.