### PR TITLE
fix: replace console.debug with console.log in initializer example.

### DIFF
--- a/examples/initializer/src/initializer.mjs
+++ b/examples/initializer/src/initializer.mjs
@@ -1,23 +1,23 @@
 export default function myInitializer () {
   return {
     onStart: () => {
-      console.debug("Loading...");
+      console.log("Loading...");
       console.time("trunk-initializer");
     },
     onProgress: ({current, total}) => {
       if (!total) {
-        console.debug("Loading...", current, "bytes");
+        console.log("Loading...", current, "bytes");
       } else {
-        console.debug("Loading...", Math.round((current/total) * 100), "%" )
+        console.log("Loading...", Math.round((current/total) * 100), "%" )
       }
     },
     onComplete: () => {
-      console.debug("Loading... done!");
+      console.log("Loading... done!");
       console.timeEnd("trunk-initializer");
     },
     onSuccess: (wasm) => {
-      console.debug("Loading... successful!");
-      console.debug("WebAssembly: ", wasm);
+      console.log("Loading... successful!");
+      console.log("WebAssembly: ", wasm);
     },
     onFailure: (error) => {
       console.warn("Loading... failed!", error);


### PR DESCRIPTION
Some chromium based browsers require that "Verbose" logging is enabled to view outputs from `console.debug`. 

Since the intention is to display what can be done with a custom initializer, I think using `console.log` would be more suitable, and practical for people just trying out `trunk`. 