### PR TITLE
chore: add version tests, and fix ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,6 +139,10 @@ jobs:
 
   test-examples:
     needs: test # Ensure test is run first.
+    env:
+      # for the CI we need to disable those checks, as we may run with a pre-release version, which would force us to
+      # replace all version requirements with pre-release requirements for this version.
+      TRUNK_REQUIRED_VERSION: '*'
     strategy:
       fail-fast: false
       max-parallel: 32

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1061,6 +1061,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2522,6 +2528,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "relative-path"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
+
+[[package]]
 name = "remove_dir_all"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2655,6 +2667,35 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rstest"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5316d2a1479eeef1ea21e7f9ddc67c191d497abc8fc3ba2467857abbb68330"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04a9df72cc1f67020b0d63ad9bfe4a323e459ea7eb68e03bd9824db49f9a4c25"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.52",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -3545,6 +3586,7 @@ dependencies = [
  "parking_lot",
  "remove_dir_all",
  "reqwest",
+ "rstest",
  "seahash",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ lightningcss = "=1.0.0-alpha.54"
 
 [dev-dependencies]
 tempfile = "3"
+rstest = "0.19"
 
 [features]
 default = ["update_check", "rustls"]

--- a/examples/initializer/Trunk.toml
+++ b/examples/initializer/Trunk.toml
@@ -1,4 +1,4 @@
-trunk-version = "0.19.0-alpha.1"
+trunk-version = ">=0.19.0"
 
 [build]
 target = "index.html"

--- a/src/config/models/core.rs
+++ b/src/config/models/core.rs
@@ -1,6 +1,7 @@
 use semver::VersionReq;
 use serde::Deserialize;
 use std::path::PathBuf;
+use std::str::FromStr;
 
 /// Config options for the core project.
 #[derive(Clone, Debug, Default, Deserialize)]
@@ -11,4 +12,17 @@ pub struct ConfigOptsCore {
     pub trunk_version: Option<VersionReq>,
     #[serde(skip)]
     pub working_directory: Option<PathBuf>,
+}
+
+impl ConfigOptsCore {
+    pub fn from_env() -> anyhow::Result<Self> {
+        Ok(Self {
+            trunk_version: std::env::var("TRUNK_REQUIRED_VERSION")
+                .ok()
+                .map(|value| VersionReq::from_str(&value))
+                .transpose()?,
+            // the working directory cannot be overridden this way
+            working_directory: None,
+        })
+    }
 }

--- a/src/config/models/mod.rs
+++ b/src/config/models/mod.rs
@@ -352,7 +352,7 @@ impl ConfigOpts {
 
     fn from_env() -> Result<Self> {
         Ok(ConfigOpts {
-            core: None,
+            core: Some(ConfigOptsCore::from_env()?),
             build: Some(envy::prefixed("TRUNK_BUILD_").from_env()?),
             watch: Some(envy::prefixed("TRUNK_WATCH_").from_env()?),
             serve: Some(envy::prefixed("TRUNK_SERVE_").from_env()?),

--- a/src/version/enforce.rs
+++ b/src/version/enforce.rs
@@ -34,3 +34,52 @@ pub(crate) fn enforce_version_with(required: &VersionReq, actual: Version) -> an
 
     Ok(())
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    // requires, actual, pass?
+    #[case("*", "0.19.0", true)]
+    #[case("*", "0.19.0-alpha.1", true)]
+    #[case("0.19", "0.19.0", true)]
+    #[case("0.19.0", "0.19.0", true)]
+    #[case("0.19.0", "0.19.1", true)]
+    // this may come unexpected, but for 0.x version, a minor version change is a breaking change
+    #[case("0.20.0", "0.19.0", false)]
+    #[case("0.19.0-alpha.2", "0.19.0-alpha.1", false)]
+    #[case("0.19.0-alpha.2", "0.19.0-alpha.2", true)]
+    #[case("0.19.0-alpha.2", "0.19.0-alpha.3", true)]
+    #[case("0.19.0-alpha.2", "0.19.0", true)]
+    #[case("0.19.0-alpha.2", "0.19.1", true)]
+    // this may come unexpected, but for 0.x version, a minor version change is a breaking change
+    #[case("0.19.0-alpha.2", "0.20.0", false)]
+    #[case("0.19.1", "0.19.0", false)]
+    #[case("0.19.1", "0.19.0-alpha.1", false)]
+    #[case("0.19.1", "0.19.1-alpha.1", false)]
+    #[case("0.20.0", "0.19.0-alpha.1", false)]
+    #[case("0.20.0", "0.19.0", false)]
+    #[case("0.20.0", "0.19.1-alpha.1", false)]
+    #[case("0.20.0", "0.19.1", false)]
+    // a way to say: 0.19.0 or greater
+    #[case(">=0.19.0", "0.19.0", true)]
+    #[case(">=0.19.0", "0.19.1", true)]
+    #[case(">=0.19.0", "0.20.0", true)]
+    // a way to say: 0.19.0-alpha.2 or greater
+    #[case(">=0.19.0-alpha.2", "0.19.0-alpha.1", false)]
+    #[case(">=0.19.0-alpha.2", "0.19.0-alpha.2", true)]
+    #[case(">=0.19.0-alpha.2", "0.19.0-rc.1", true)]
+    #[case(">=0.19.0-alpha.2", "0.19.0", true)]
+    // The following case comes unexpected
+    #[case(">=0.19.0-alpha.2", "0.20.0-alpha.1", false)]
+    #[case(">=0.19.0-alpha.2", "0.20.0", true)]
+    fn test_requires(
+        #[case] required: VersionReq,
+        #[case] actual: Version,
+        #[case] expected: bool,
+    ) {
+        assert_eq!(expected, enforce_version_with(&required, actual).is_ok());
+    }
+}


### PR DESCRIPTION
Add some tests to validate version enforcement. Also fix the CI, as it looks like `0.19.0-alpha.1` is not intended to match other pre-release versions.