### PR TITLE
Remove old nix unstable note from site

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -50,8 +50,6 @@ wget -qO- https://github.com/trunk-rs/trunk/releases/download/0.17.10/trunk-x86_
 
 ### NixOS
 
-**Note:** `trunk` is currently in the `unstable` channel. It should be part of the next release.
-
 ```bash
 nix-env -i trunk
 ```


### PR DESCRIPTION
Removes outdated note from the site about trunk only being in the unstable nix channels as it is currently [in 23.11](https://search.nixos.org/packages?channel=23.11&show=trunk&type=packages)