### PR TITLE
feat: raise error for self closing script tags.

### DIFF
--- a/src/config/models/build.rs
+++ b/src/config/models/build.rs
@@ -131,4 +131,12 @@ pub struct ConfigOptsBuild {
     #[serde(default)]
     #[arg(long)]
     pub no_sri: bool,
+
+    /// Ignore error's related to self closing script elements, and instead issue a warning.
+    ///
+    /// Since this error can cause the HTML output to be truncated, only enable this in case you
+    /// are sure it is caused due to a false positive.
+    #[serde(default)]
+    #[arg(long)]
+    pub ignore_script_error: bool,
 }

--- a/src/config/rt/build.rs
+++ b/src/config/rt/build.rs
@@ -76,6 +76,8 @@ pub struct RtcBuild {
     pub no_minification: bool,
     /// Allow disabling SRI
     pub no_sri: bool,
+    /// Ignore error's due to self closed script tags, instead will issue a warning.
+    pub ignore_script_error: bool,
 }
 
 impl RtcBuild {
@@ -174,6 +176,7 @@ impl RtcBuild {
             accept_invalid_certs: opts.accept_invalid_certs,
             no_minification: opts.no_minification,
             no_sri: opts.no_sri,
+            ignore_script_error: opts.ignore_script_error,
         })
     }
 
@@ -216,6 +219,7 @@ impl RtcBuild {
             accept_invalid_certs: None,
             no_minification: false,
             no_sri: false,
+            ignore_script_error: false,
         })
     }
 }

--- a/src/pipelines/html.rs
+++ b/src/pipelines/html.rs
@@ -83,7 +83,7 @@ impl HtmlPipeline {
 
         // Open the source HTML file for processing.
         let raw_html = fs::read(&self.target_html_path).await?;
-        let mut target_html = Document::new(raw_html);
+        let mut target_html = Document::new(raw_html, self.cfg.ignore_script_error)?;
         let mut partial_assets = vec![];
 
         // Since the `lol_html` doesn't provide an iterator for elements, we must use our own id.
@@ -95,41 +95,39 @@ impl HtmlPipeline {
         //
         // This is the first parsing of the HTML meaning it is pretty likely to receive
         // invalid HTML at this stage.
-        target_html
-            .select_mut(r#"link[data-trunk], script[data-trunk]"#, |el| {
-                'l: {
-                    el.set_attribute(TRUNK_ID, &id.to_string())?;
+        target_html.select_mut(r#"link[data-trunk], script[data-trunk]"#, |el| {
+            'l: {
+                el.set_attribute(TRUNK_ID, &id.to_string())?;
 
-                    // Both are function pointers, no need to branch out.
-                    let asset_constructor = match el.tag_name().as_str() {
-                        "link" => TrunkAssetReference::Link,
-                        "script" => TrunkAssetReference::Script,
-                        // Just an early break since we won't do anything else.
-                        _ => break 'l,
-                    };
+                // Both are function pointers, no need to branch out.
+                let asset_constructor = match el.tag_name().as_str() {
+                    "link" => TrunkAssetReference::Link,
+                    "script" => TrunkAssetReference::Script,
+                    // Just an early break since we won't do anything else.
+                    _ => break 'l,
+                };
 
-                    // Accumulate all attrs. The main reason we collect this as
-                    // raw data instead of passing around the link itself, is the lifetime
-                    // requirements of elements used in `lol_html::html_content::HtmlRewriter`.
-                    let attrs = el.attributes().iter().fold(Attrs::new(), |mut acc, attr| {
-                        acc.insert(attr.name(), attr.value());
-                        acc
-                    });
+                // Accumulate all attrs. The main reason we collect this as
+                // raw data instead of passing around the link itself, is the lifetime
+                // requirements of elements used in `lol_html::html_content::HtmlRewriter`.
+                let attrs = el.attributes().iter().fold(Attrs::new(), |mut acc, attr| {
+                    acc.insert(attr.name(), attr.value());
+                    acc
+                });
 
-                    let asset = TrunkAsset::from_html(
-                        self.cfg.clone(),
-                        self.target_html_dir.clone(),
-                        self.ignore_chan.clone(),
-                        asset_constructor(attrs),
-                        id,
-                    );
+                let asset = TrunkAsset::from_html(
+                    self.cfg.clone(),
+                    self.target_html_dir.clone(),
+                    self.ignore_chan.clone(),
+                    asset_constructor(attrs),
+                    id,
+                );
 
-                    partial_assets.push(asset);
-                }
-                id += 1;
-                Ok(())
-            })
-            .context("error parsing HTML, check HTML validity")?;
+                partial_assets.push(asset);
+            }
+            id += 1;
+            Ok(())
+        })?;
 
         let mut assets: Vec<TrunkAsset> = futures_util::future::join_all(partial_assets)
             .await


### PR DESCRIPTION
This adds a warning for when a self closing script tag is found.

Related Issue: https://github.com/trunk-rs/trunk/issues/742

The exact message could be changed to whatever you prefer, but I do think that linking the discussion is a good idea instead of stacking a ton of information in the warn message.

Makes use of [`Element::is_self_closing`](https://docs.rs/lol_html/latest/lol_html/html_content/struct.Element.html#method.is_self_closing) to detect if the tag is self closed. This checks if the "/" character is in the end of the opening tag, not if the tag could have one. 

![image](https://github.com/trunk-rs/trunk/assets/111659262/98b75625-4608-4fee-9558-63399936cf99)

Edit: We can also add a general check in the Document initializer, that would check the script tags, and/or anything else.
