### PR TITLE
chore: clean up a few things around the script element check

### DIFF
--- a/src/config/models/build.rs
+++ b/src/config/models/build.rs
@@ -143,11 +143,11 @@ pub struct ConfigOptsBuild {
     #[arg(long)]
     pub no_sri: bool,
 
-    /// Ignore error's related to self closing script elements, and instead issue a warning.
+    /// Ignore error's related to self-closing script elements, and instead issue a warning.
     ///
-    /// Since this error can cause the HTML output to be truncated, only enable this in case you
+    /// Since this issue can cause the HTML output to be truncated, only enable this in case you
     /// are sure it is caused due to a false positive.
     #[serde(default)]
     #[arg(long)]
-    pub ignore_script_error: bool,
+    pub allow_self_closing_script: bool,
 }

--- a/src/config/models/mod.rs
+++ b/src/config/models/mod.rs
@@ -362,6 +362,10 @@ impl ConfigOpts {
                 if l.no_sri {
                     g.no_sri = true;
                 }
+                // NOTE: this can not be disabled in the cascade.
+                if l.allow_self_closing_script {
+                    g.allow_self_closing_script = true;
+                }
 
                 Some(g)
             }

--- a/src/config/rt/build.rs
+++ b/src/config/rt/build.rs
@@ -78,8 +78,8 @@ pub struct RtcBuild {
     pub minify: Minify,
     /// Allow disabling SRI
     pub no_sri: bool,
-    /// Ignore error's due to self closed script tags, instead will issue a warning.
-    pub ignore_script_error: bool,
+    /// Ignore error's due to self-closed script tags, instead will issue a warning.
+    pub allow_self_closing_script: bool,
 }
 
 impl RtcBuild {
@@ -185,7 +185,7 @@ impl RtcBuild {
             accept_invalid_certs: opts.accept_invalid_certs,
             minify,
             no_sri: opts.no_sri,
-            ignore_script_error: opts.ignore_script_error,
+            allow_self_closing_script: opts.allow_self_closing_script,
         })
     }
 
@@ -228,7 +228,7 @@ impl RtcBuild {
             accept_invalid_certs: None,
             minify: Minify::Never,
             no_sri: false,
-            ignore_script_error: false,
+            allow_self_closing_script: false,
         })
     }
 

--- a/src/pipelines/html.rs
+++ b/src/pipelines/html.rs
@@ -1,7 +1,7 @@
 //! Source HTML pipelines.
 
 use crate::{
-    common::html_rewrite::Document,
+    common::html_rewrite::{Document, DocumentOptions},
     config::{RtcBuild, WsProtocol},
     hooks::{spawn_hooks, wait_hooks},
     pipelines::{
@@ -83,7 +83,12 @@ impl HtmlPipeline {
 
         // Open the source HTML file for processing.
         let raw_html = fs::read(&self.target_html_path).await?;
-        let mut target_html = Document::new(raw_html, self.cfg.ignore_script_error)?;
+        let mut target_html = Document::new(
+            raw_html,
+            DocumentOptions {
+                allow_self_closing_script: self.cfg.allow_self_closing_script,
+            },
+        )?;
         let mut partial_assets = vec![];
 
         // Since the `lol_html` doesn't provide an iterator for elements, we must use our own id.


### PR DESCRIPTION
* Rename the flag to `allow_self_closing_script`, which may be verbose, but it's also not recommended to use anyway. And it feels a bit more descriptive, we don't ignore script errors, but allow the error of a self-closing script tag.
* Ensure that the configuration from the config file as well as from the CLI gets evaluated.
* Introduce an "options" struct, making future enhancements a bit simpler.
* Use plain strings for errors, vs concatenating and formatting.

@airblast-dev Maybe you want to double check. Most notably, any script element (not only trunk ones) seem to cause the issue. So I warn/error about all of them.