### PR TITLE
feat: provide total wasm size to the initializer

### DIFF
--- a/src/pipelines/rust/initializer.js
+++ b/src/pipelines/rust/initializer.js
@@ -1,12 +1,12 @@
-async function __trunkInitializer(source, initializer) {
+async function __trunkInitializer(init, source, sourceSize, initializer) {
   if (initializer === undefined) {
     return await init(source);
   }
 
-  return await __trunkInitWithProgress(source, initializer);
+  return await __trunkInitWithProgress(init, source, sourceSize, initializer);
 }
 
-async function __trunkInitWithProgress(source, initializer) {
+async function __trunkInitWithProgress(init, source, sourceSize, initializer) {
 
   const {
     onStart, onProgress, onComplete, onSuccess, onFailure
@@ -21,7 +21,7 @@ async function __trunkInitWithProgress(source, initializer) {
         const status = response.status;
         const statusText = response.statusText;
 
-        const total = +response.headers.get("Content-Length");
+        const total = sourceSize;
         let current = 0;
 
         const stream = new ReadableStream({

--- a/src/pipelines/rust/mod.rs
+++ b/src/pipelines/rust/mod.rs
@@ -574,7 +574,7 @@ impl RustApp {
 
         tracing::debug!("copying {wasm_path} to {}", wasm_path_dist.display());
 
-        fs::copy(wasm_path, wasm_path_dist)
+        fs::copy(wasm_path, &wasm_path_dist)
             .await
             .context("error copying wasm file to stage dir")?;
 
@@ -659,6 +659,10 @@ impl RustApp {
             }
         }
 
+        // wasm size
+
+        let wasm_size = fs::metadata(&wasm_path_dist).await?.len();
+
         // initializer
 
         let initializer = match &self.initializer {
@@ -691,6 +695,7 @@ impl RustApp {
             cfg: self.cfg.clone(),
             js_output: hashed_js_name,
             wasm_output: hashed_wasm_name,
+            wasm_size,
             ts_output,
             loader_shim_output: hashed_loader_name,
             r#type: self.app_type,

--- a/src/pipelines/rust/output.rs
+++ b/src/pipelines/rust/output.rs
@@ -17,6 +17,8 @@ pub struct RustAppOutput {
     pub js_output: String,
     /// The filename of the generated WASM file written to the dist dir.
     pub wasm_output: String,
+    /// The size of the WASM file
+    pub wasm_size: u64,
     /// The filename of the generated .ts file written to the dist dir.
     pub ts_output: Option<String>,
     /// The filename of the generated loader shim script for web workers written to the dist dir.
@@ -140,11 +142,12 @@ init('{base}{wasm}');{bind}
 import init{import} from '{base}{js}';
 import initializer from '{base}{initializer}';
 
-await __trunkInitializer('{base}{wasm}', initializer());
+await __trunkInitializer(init, '{base}{wasm}', {size}, initializer());
 
 {bind}
 </script>"#,
                 init = include_str!("initializer.js"),
+                size = self.wasm_size,
             ),
         }
     }


### PR DESCRIPTION
The initializer tries to get the total WASM size from the response. This can be done using the `Content-Length` header, but that approach has some downsides. First of all, it's not required and my be missing.

Second, it will report the "on the wire" size of the response, the stream which already content encoded. If that includes compression, then there is no way to evaluate the total (uncompressed) size, or the currently read (compressed) bytes. So there is no way to sum up the bytes read (decoded, uncompressed) towards the total (compressed).

On the other side, during the bundling process, we do know the total WASM size, and we also create hashes for it, so that we ensure its integrity. So we can also use that size as a total.