### PR TITLE
feat: Add extra request headers on proxied requests.

### DIFF
--- a/schemas/config.json
+++ b/schemas/config.json
@@ -360,6 +360,14 @@
           "default": false,
           "type": "boolean"
         },
+        "request_headers": {
+          "description": "Additional headers to send in proxied requests.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "rewrite": {
           "description": "An optional URI prefix which is to be used as the base URI for proxying requests, which defaults to the URI of the backend.\n\nWhen a value is specified, requests received on this URI will have this URI segment replaced with the URI of the `backend`.",
           "type": [
@@ -466,6 +474,15 @@
             "boolean",
             "null"
           ]
+        },
+        "proxy_request_headers": {
+          "description": "Configure additional headers to send in proxied requests.",
+          "default": {},
+          "deprecated": true,
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "proxy_rewrite": {
           "description": "The URI on which to accept requests which are to be rewritten and proxied to backend [default: None]",

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -145,6 +145,7 @@ impl Serve {
                 ws: proxy_ws,
                 insecure: proxy_insecure,
                 no_system_proxy: proxy_no_system_proxy,
+                request_headers: Default::default(),
             });
         }
 

--- a/src/config/models/mod.rs
+++ b/src/config/models/mod.rs
@@ -105,6 +105,7 @@ impl ConfigModel for Configuration {
                 ws: self.serve.proxy_ws.unwrap_or_default(),
                 insecure: self.serve.proxy_insecure.unwrap_or_default(),
                 no_system_proxy: self.serve.proxy_no_system_proxy.unwrap_or_default(),
+                request_headers: self.serve.proxy_request_headers.clone(),
             })
         }
 

--- a/src/config/models/proxy.rs
+++ b/src/config/models/proxy.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::{config::models::ConfigModel, config::types::Uri};
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -23,6 +25,9 @@ pub struct Proxy {
     #[serde(alias = "no-system-proxy")]
     #[serde(default)]
     pub no_system_proxy: bool,
+    /// Additional headers to send in proxied requests.
+    #[serde(default)]
+    pub request_headers: HashMap<String, String>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, JsonSchema)]

--- a/src/config/models/serve.rs
+++ b/src/config/models/serve.rs
@@ -70,6 +70,10 @@ pub struct Serve {
     #[serde(default)]
     #[deprecated]
     pub proxy_no_system_proxy: Option<bool>,
+    /// Configure additional headers to send in proxied requests.
+    #[serde(default)]
+    #[deprecated]
+    pub proxy_request_headers: HashMap<String, String>,
 }
 
 impl Default for Serve {
@@ -94,6 +98,7 @@ impl Default for Serve {
             proxy_ws: None,
             proxy_insecure: None,
             proxy_no_system_proxy: None,
+            proxy_request_headers: Default::default(),
         }
     }
 }

--- a/src/config/rt/serve.rs
+++ b/src/config/rt/serve.rs
@@ -92,6 +92,7 @@ impl RtcServe {
             proxy_ws: _,
             proxy_insecure: _,
             proxy_no_system_proxy: _,
+            proxy_request_headers: _,
         } = config.serve;
 
         let tls = tls_config(

--- a/src/serve/proxy.rs
+++ b/src/serve/proxy.rs
@@ -4,6 +4,7 @@ use anyhow::Context;
 use axum::http::Uri;
 use axum::Router;
 use console::Emoji;
+use hyper::HeaderMap;
 use reqwest::Client;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
@@ -31,10 +32,11 @@ impl ProxyBuilder {
         ws: bool,
         backend: &Uri,
         rewrite: Option<String>,
+        request_headers: HeaderMap,
         opts: ProxyClientOptions,
     ) -> anyhow::Result<Self> {
         if ws {
-            let handler = ProxyHandlerWebSocket::new(backend.clone(), rewrite);
+            let handler = ProxyHandlerWebSocket::new(backend.clone(), rewrite, request_headers);
             tracing::info!(
                 "{}proxying websocket {} -> {}",
                 SERVER,
@@ -47,7 +49,8 @@ impl ProxyBuilder {
             let no_sys_proxy = opts.no_system_proxy;
             let insecure = opts.insecure;
             let client = self.clients.get_client(opts)?;
-            let handler = ProxyHandlerHttp::new(client, backend.clone(), rewrite);
+
+            let handler = ProxyHandlerHttp::new(client, backend.clone(), rewrite, request_headers);
             tracing::info!(
                 "{}proxying {} -> {}{}{}",
                 SERVER,


### PR DESCRIPTION
Adds `request_headers` field to proxy config, which allows extra headers to be added when proxying HTTP or WS requests.

This sets (and overrides if already set) headers with the configured values. For example, one might add to the configuration
```toml
[[proxy]]
request_headers.authorization = "Bearer ey..."
```

No tests yet, mainly as no existing tests exercise trunk at the level required here; this might need quite a bit of scaffolding to make tests possible.

Fixes: #820 