### PR TITLE
Allow injecting request headers on the proxy module

### DIFF
--- a/examples/proxy/Trunk.toml
+++ b/examples/proxy/Trunk.toml
@@ -21,6 +21,7 @@ ws = true
 # E.G., `/api/v1/resource/x/y/z` -> `/resource/x/y/z`
 rewrite = "/api/v1/"
 backend = "http://localhost:9090/"
+request_headers = { "x-api-key" = "some-special-key" }
 
 [[proxy]]
 # This proxy specifies only the backend, which is the only required field. In this example,

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -361,9 +361,8 @@
           "type": "boolean"
         },
         "request_headers": {
-          "description": "Configure additional headers to send in proxied requests.",
+          "description": "A set of headers to pass to the proxied backend.",
           "default": {},
-          "deprecated": true,
           "type": "object",
           "additionalProperties": {
             "type": "string"

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -360,6 +360,15 @@
           "default": false,
           "type": "boolean"
         },
+        "request_headers": {
+          "description": "Configure additional headers to send in proxied requests.",
+          "default": {},
+          "deprecated": true,
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "rewrite": {
           "description": "An optional URI prefix which is to be used as the base URI for proxying requests, which defaults to the URI of the backend.\n\nWhen a value is specified, requests received on this URI will have this URI segment replaced with the URI of the `backend`.",
           "type": [

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -141,6 +141,7 @@ impl Serve {
             // we have a single proxy from the command line
             config.proxies.0.push(Proxy {
                 backend: backend.into(),
+                request_headers: Default::default(),
                 rewrite: proxy_rewrite,
                 ws: proxy_ws,
                 insecure: proxy_insecure,

--- a/src/config/models/mod.rs
+++ b/src/config/models/mod.rs
@@ -101,6 +101,7 @@ impl ConfigModel for Configuration {
             log::warn!("The proxy fields in the configuration are deprecated and will be removed in a future version. Migrate those settings into an entry of the `proxies` field, which allows adding more than one.");
             self.proxies.0.push(Proxy {
                 backend,
+                request_headers: Default::default(),
                 rewrite: self.serve.proxy_rewrite.take(),
                 ws: self.serve.proxy_ws.unwrap_or_default(),
                 insecure: self.serve.proxy_insecure.unwrap_or_default(),

--- a/src/config/models/proxy.rs
+++ b/src/config/models/proxy.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::{config::models::ConfigModel, config::types::Uri};
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -13,6 +15,9 @@ pub struct Proxy {
     /// When a value is specified, requests received on this URI will have this URI segment
     /// replaced with the URI of the `backend`.
     pub rewrite: Option<String>,
+    /// A set of headers to pass to the proxied backend.
+    #[serde(default)]
+    pub request_headers: HashMap<String, String>,
     /// Configure the proxy for handling WebSockets.
     #[serde(default)]
     pub ws: bool,

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -367,6 +367,7 @@ fn router(state: Arc<State>, cfg: Arc<RtcServe>) -> Result<Router> {
         builder = builder.register_proxy(
             proxy.ws,
             &proxy.backend,
+            &proxy.request_headers,
             proxy.rewrite.clone(),
             ProxyClientOptions {
                 insecure: proxy.insecure,

--- a/src/serve/proxy.rs
+++ b/src/serve/proxy.rs
@@ -30,6 +30,7 @@ impl ProxyBuilder {
         mut self,
         ws: bool,
         backend: &Uri,
+        request_headers: &HashMap<String, String>,
         rewrite: Option<String>,
         opts: ProxyClientOptions,
     ) -> anyhow::Result<Self> {
@@ -47,12 +48,18 @@ impl ProxyBuilder {
             let no_sys_proxy = opts.no_system_proxy;
             let insecure = opts.insecure;
             let client = self.clients.get_client(opts)?;
-            let handler = ProxyHandlerHttp::new(client, backend.clone(), rewrite);
+            let handler =
+                ProxyHandlerHttp::new(client, backend.clone(), request_headers.clone(), rewrite);
             tracing::info!(
-                "{}proxying {} -> {}{}{}",
+                "{}proxying {} -> {} {} {}{}",
                 SERVER,
                 handler.path(),
                 &backend,
+                &request_headers
+                    .iter()
+                    .map(|(header_name, header_value)| format!("{header_name}={header_value}"))
+                    .collect::<Vec<String>>()
+                    .join(";"),
                 if no_sys_proxy {
                     "; ignoring system proxy"
                 } else {


### PR DESCRIPTION
Allows you to define extra set of headers and even override the host header to the upstream source.

```toml
[[proxy]]
# This proxy example has a backend and a rewrite field. Requests received on `rewrite` will be
# proxied to the backend after stripping the `rewrite`.
# E.G., `/api/v1/resource/x/y/z` -> `/resource/x/y/z`
rewrite = "/api/v1/"
backend = "http://localhost:9090/"
request_headers = { "x-api-key" = "some-special-key" }
```

Closes #820