### PR TITLE
chore: replace ansi_term with nu-ansi-term

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,15 +80,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3761,7 +3752,6 @@ dependencies = [
 name = "trunk"
 version = "0.21.0-alpha.4"
 dependencies = [
- "ansi_term",
  "anyhow",
  "async-recursion",
  "axum",
@@ -3789,6 +3779,7 @@ dependencies = [
  "minify-js",
  "notify",
  "notify-debouncer-full",
+ "nu-ansi-term",
  "once_cell",
  "open",
  "oxipng",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ lightningcss = "=1.0.0-alpha.57"
 crates_io_api = { version = "0.11", default-features = false, optional = true }
 
 [target.'cfg(windows)'.dependencies]
-ansi_term = "0.12"
+nu-ansi-term = "0.46"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ fn init_color(cli: &Trunk) -> bool {
 
     #[cfg(windows)]
     if colored {
-        if let Err(err) = ansi_term::enable_ansi_support() {
+        if let Err(err) = nu_ansi_term::enable_ansi_support() {
             eprintln!("error enabling ANSI support: {:?}", err);
         }
     }


### PR DESCRIPTION
`ansi_term` is not maintained, and `nu-ansi-term` is widely used as the replacement.