### PR TITLE
chore: remove unncessary cargo sparse registry config

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[registries.crates-io]
-protocol = "sparse"


### PR DESCRIPTION
This config has been set as default since Rust 1.70.

https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html#sparse-by-default-for-cratesio

