### PR TITLE
Keep "modulepreload" links with --no-sri flag

### DIFF
--- a/src/pipelines/rust/sri.rs
+++ b/src/pipelines/rust/sri.rs
@@ -71,20 +71,21 @@ impl SriBuilder {
         T: AsRef<[u8]>,
         Fut: Future<Output = Result<T, E>>,
     {
-        if !matches!(self.r#type, IntegrityType::None) {
-            let name = name.into();
-            let digest = OutputDigest::generate_async(self.r#type, source).await?;
-            tracing::debug!(
-                "recording SRI record - type: {:?}. name: {name}, value: {digest:?}",
-                self.r#type,
-            );
-            let key = SriKey { r#type, name };
-            let entry = SriEntry { digest, options };
-            if let Some(record) = self.result.integrities.iter_mut().find(|(k, _)| k == &key) {
-                record.1 = entry;
-            } else {
-                self.result.integrities.push((key, entry));
-            }
+        let name = name.into();
+        let digest = match self.r#type {
+            IntegrityType::None => OutputDigest::default(),
+            _ => OutputDigest::generate_async(self.r#type, source).await?,
+        };
+        tracing::debug!(
+            "recording SRI record - type: {:?}. name: {name}, value: {digest:?}",
+            self.r#type,
+        );
+        let key = SriKey { r#type, name };
+        let entry = SriEntry { digest, options };
+        if let Some(record) = self.result.integrities.iter_mut().find(|(k, _)| k == &key) {
+            record.1 = entry;
+        } else {
+            self.result.integrities.push((key, entry));
         }
 
         Ok(())
@@ -149,15 +150,18 @@ impl SriResult {
         cross_origin: CrossOrigin,
     ) -> anyhow::Result<()> {
         for (SriKey { r#type, name }, SriEntry { digest, options }) in &self.integrities {
-            if let Some(integrity) = digest.to_integrity_value() {
-                let preload = format!(
-                    r#"
-<link rel="{type}" href="{base}{name}" crossorigin={cross_origin} integrity="{integrity}"{options}>"#,
-                );
-                location
-                    .append_html(head, &preload)
-                    .context("Unable to write SRI.")?;
-            }
+            let preload = if let Some(integrity) = digest.to_integrity_value() {
+                format!(
+                    r#"<link rel="{type}" href="{base}{name}" crossorigin={cross_origin} integrity="{integrity}"{options}>"#,
+                )
+            } else {
+                format!(
+                    r#"<link rel="{type}" href="{base}{name}" crossorigin={cross_origin}{options}>"#,
+                )
+            };
+            location
+                .append_html(head, &preload)
+                .context("Unable to write SRI.")?;
         }
 
         Ok(())


### PR DESCRIPTION
Following issue https://github.com/trunk-rs/trunk/issues/838 I had to use the `--no-sri` flag to avoid assets not loading due to a invalid integrity hash compared to in-cache assets. I noticed afterwards that my website takes a performance hit on FCP because of the missing "preload" & "modulepreload" links.

I saw that trunk currently puts a lot of elements together with the generation of the integrity hash such as "type","modulepreload","crossorigin" while they're not necessarily co-dependent and can be used on their own.

How it is now with the `--no-sri` flag:
```
<link href=/static/assets/output-6f824cdea32a1ab3.css rel=stylesheet>
```
After this fix:
```
<link href=/static/assets/output-6f824cdea32a1ab3.css rel=stylesheet>
<link crossorigin href=/static/assets/front-f17ab0ceaa45a239.js rel=modulepreload>
<link crossorigin href=/static/assets/snippets/dioxus-interpreter-js-7c1300c6684e1811/src/js/common.js rel=modulepreload>
<link crossorigin href=/static/assets/snippets/dioxus-interpreter-js-7c1300c6684e1811/inline0.js rel=modulepreload>
<link crossorigin href=/static/assets/snippets/dioxus-web-84af743b887ebc54/src/eval.js rel=modulepreload>
<link crossorigin href=/static/assets/snippets/dioxus-web-84af743b887ebc54/inline0.js rel=modulepreload>
<link crossorigin href=/static/assets/snippets/dioxus-web-84af743b887ebc54/inline1.js rel=modulepreload>
<link as=fetch crossorigin href=/static/assets/front-f17ab0ceaa45a239_bg.wasm rel=preload type=application/wasm>
```

These are the verbose logs after the changes for this case:
```
DEBUG recording SRI record - type: None. name: front-f17ab0ceaa45a239.js, value: OutputDigest { integrity: None, hash: "" }
DEBUG recording SRI record - type: None. name: snippets/dioxus-interpreter-js-7c1300c6684e1811/inline0.js, value: OutputDigest { integrity: None, hash: "" }
DEBUG recording SRI record - type: None. name: snippets/dioxus-web-84af743b887ebc54/inline0.js, value: OutputDigest { integrity: None, hash: "" }
DEBUG recording SRI record - type: None. name: snippets/dioxus-web-84af743b887ebc54/src/eval.js, value: OutputDigest { integrity: None, hash: "" }
DEBUG recording SRI record - type: None. name: snippets/dioxus-web-84af743b887ebc54/inline1.js, value: OutputDigest { integrity: None, hash: "" }
DEBUG recording SRI record - type: None. name: snippets/dioxus-interpreter-js-7c1300c6684e1811/src/js/common.js, value: OutputDigest { integrity: None, hash: "" }
DEBUG wasm-opt is turned off    
DEBUG recording SRI record - type: None. name: front-f17ab0ceaa45a239_bg.wasm, value: OutputDigest { integrity: None, hash: "" }
DEBUG rust build complete
```

I have tested this and browsers (firefox & chrome) do not display any error or warning without the integrity attribute present.