### PR TITLE
fix: ensure that the base directory is applied as "current"

### DIFF
--- a/src/pipelines/sass.rs
+++ b/src/pipelines/sass.rs
@@ -131,7 +131,13 @@ impl Sass {
 
         let rel_path = common::strip_prefix(&self.asset.path);
         tracing::debug!(path = ?rel_path, "compiling sass/scss");
-        common::run_command(Application::Sass.name(), &sass, args).await?;
+        common::run_command(
+            Application::Sass.name(),
+            &sass,
+            args,
+            &self.cfg.working_directory,
+        )
+        .await?;
 
         let css = fs::read_to_string(&temp_target_file_path)
             .await

--- a/src/pipelines/tailwind_css.rs
+++ b/src/pipelines/tailwind_css.rs
@@ -104,7 +104,13 @@ impl TailwindCss {
 
         let rel_path = common::strip_prefix(&self.asset.path);
         tracing::debug!(path = ?rel_path, "compiling tailwind css");
-        common::run_command(Application::TailwindCss.name(), &tailwind, &args).await?;
+        common::run_command(
+            Application::TailwindCss.name(),
+            &tailwind,
+            &args,
+            &self.cfg.working_directory,
+        )
+        .await?;
 
         let css = fs::read_to_string(&file_path).await?;
         fs::remove_file(&file_path).await?;


### PR DESCRIPTION
Trunk claims that the base directory of the configuration is considered the "current" directory. However, for some cargo features, setting --manifest-path is not enough. So we do apply the base dir explicitly.