### PR TITLE
fix: create parent dirs for dist folder if don't exist

### DIFF
--- a/src/config/rt/build.rs
+++ b/src/config/rt/build.rs
@@ -137,7 +137,7 @@ impl RtcBuild {
         // have a reliable FS path to work with, we make an exception here.
         let final_dist = core.working_directory.join(&build.dist);
         if !final_dist.exists() {
-            std::fs::create_dir(&final_dist)
+            std::fs::create_dir_all(&final_dist)
                 .or_else(|err| match err.kind() {
                     ErrorKind::AlreadyExists => Ok(()),
                     _ => Err(err),

--- a/src/config/rt/build.rs
+++ b/src/config/rt/build.rs
@@ -6,7 +6,7 @@ use crate::config::{
     Hooks,
 };
 use anyhow::{ensure, Context};
-use std::{collections::HashMap, io::ErrorKind, ops::Deref, path::PathBuf};
+use std::{collections::HashMap, ops::Deref, path::PathBuf};
 
 /// Config options for the cargo build command
 #[derive(Clone, Debug)]
@@ -136,14 +136,10 @@ impl RtcBuild {
         // we would want to avoid such an action at this layer, however to ensure that other layers
         // have a reliable FS path to work with, we make an exception here.
         let final_dist = core.working_directory.join(&build.dist);
-        if !final_dist.exists() {
-            std::fs::create_dir_all(&final_dist)
-                .or_else(|err| match err.kind() {
-                    ErrorKind::AlreadyExists => Ok(()),
-                    _ => Err(err),
-                })
-                .with_context(|| format!("error creating final dist directory {final_dist:?}"))?;
-        }
+
+        std::fs::create_dir_all(&final_dist)
+            .with_context(|| format!("error creating final dist directory {final_dist:?}"))?;
+
         let final_dist = final_dist
             .canonicalize()
             .context("error taking canonical path to dist dir")?;

--- a/src/pipelines/copy_dir_test.rs
+++ b/src/pipelines/copy_dir_test.rs
@@ -13,7 +13,7 @@ async fn setup_test_config() -> Result<(tempfile::TempDir, Arc<RtcBuild>, PathBu
     let tmpdir = tempfile::tempdir().context("error building tempdir for test")?;
     let cfg = Arc::new(RtcBuild::new_test(tmpdir.path()).await?);
     let asset_dir = tmpdir.path().join("test_dir");
-    tokio::fs::create_dir(&asset_dir)
+    tokio::fs::create_dir_all(&asset_dir)
         .await
         .context("error creating test dir")?;
     let asset_file = asset_dir.join("test_file");

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -542,12 +542,7 @@ mod archive {
                     }
                 }
                 Self::None(in_file) => {
-                    let create_dir_result = std::fs::create_dir(target_directory);
-                    if let Err(e) = &create_dir_result {
-                        if e.kind() != std::io::ErrorKind::AlreadyExists {
-                            create_dir_result.context("failed to open file for")?;
-                        }
-                    }
+                    std::fs::create_dir_all(target_directory).context("failed to open file for")?;
 
                     let mut out_file_path = target_directory.to_path_buf();
                     out_file_path.push(file);


### PR DESCRIPTION
fixes #826

there two more places where we still use `create_dir` instead of `create_dir_all` [here](https://github.com/search?q=repo%3Atrunk-rs%2Ftrunk%20create_dir(&type=code)). maybe we want to fix those as well? and ideally have a linting rule to always use `create_dir_all` instead of `create_dir` as we already use a mix of both accross the repo.

## steps to reproduce

- build the project. `cargo build`
- navigate to `examples/yew`
- modify the `dist` value in `examples/yew/Trunk.toml` to something like `dist = "dist/sub"`.
- run the locally built version of trunk on this directory: `../../target/debug/trunk build`

on `main` you should get the error that parent dir doesn't exists.
on this branch, the parent dir should be created and the build passes.