### PR TITLE
fix[serve]: use valid ipv6 addr literal format

### DIFF
--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -56,12 +56,12 @@ impl ServeSystem {
         )
         .await?;
         let prefix = if cfg.tls.is_some() { "https" } else { "http" };
-        let address = match cfg.addresses.first() {
-            Some(address) => *address,
-            None => IpAddr::V4(Ipv4Addr::LOCALHOST),
-        };
+        let address = cfg.addresses.first().map_or_else(
+            || SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), cfg.port),
+            |ipaddr| SocketAddr::new(*ipaddr, cfg.port),
+        );
         let base = cfg.serve_base()?;
-        let open_http_addr = format!("{prefix}://{address}:{port}{base}", port = cfg.port);
+        let open_http_addr = format!("{prefix}://{address}{base}");
         Ok(Self {
             cfg,
             watch,


### PR DESCRIPTION
Fixes #824. As suggested by @ctron, I switched to using `SocketAddr` instead of `IpAddr`. Works as expected on Windows 11 + Firefox.

IPv6 address literal format is specified by [RFC3986](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2).