### PR TITLE
fix[serve]: config file option `serve.open` is ignored

### DIFF
--- a/schemas/config.json
+++ b/schemas/config.json
@@ -428,6 +428,11 @@
           "default": false,
           "type": "boolean"
         },
+        "open": {
+          "description": "Open a browser tab once the initial build is complete [default: false]",
+          "default": false,
+          "type": "boolean"
+        },
         "port": {
           "description": "The port to serve on [default: 8080]",
           "default": 8080,

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -29,7 +29,8 @@ pub struct Serve {
     pub port: Option<u16>,
     /// Open a browser tab once the initial build is complete [default: false]
     #[arg(long, env = "TRUNK_SERVE_OPEN")]
-    pub open: bool,
+    #[arg(default_missing_value="true", num_args=0..=1)]
+    pub open: Option<bool>,
     /// Disable auto-reload of the web app
     #[arg(long, env = "TRUNK_SERVE_NO_AUTORELOAD")]
     #[arg(default_missing_value="true", num_args=0..=1)]
@@ -98,7 +99,7 @@ impl Serve {
             address,
             prefer_address_family,
             port,
-            open: _,
+            open,
             proxy:
                 ProxyArgs {
                     proxy_backend,
@@ -122,6 +123,7 @@ impl Serve {
 
         config.serve.addresses = address.unwrap_or(config.serve.addresses);
         config.serve.port = port.unwrap_or(config.serve.port);
+        config.serve.open = open.unwrap_or(config.serve.open);
         config.serve.prefer_address_family =
             prefer_address_family.or(config.serve.prefer_address_family);
         config.serve.serve_base = serve_base.or(config.serve.serve_base);
@@ -173,7 +175,8 @@ impl Serve {
                 enable_cooldown: self.watch.enable_cooldown,
                 no_error_reporting: cfg.serve.no_error_reporting,
             },
-            open: self.open,
+            // This will be the effective value for `serve.open` during runtime.
+            open: self.open.unwrap_or(cfg.serve.open),
         })
         .await?;
 

--- a/src/config/models/serve.rs
+++ b/src/config/models/serve.rs
@@ -23,6 +23,9 @@ pub struct Serve {
     /// The port to serve on [default: 8080]
     #[serde(default = "default::port")]
     pub port: u16,
+    /// Open a browser tab once the initial build is complete [default: false]
+    #[serde(default)]
+    pub open: bool,
     /// Disable auto-reload of the web app
     #[serde(default)]
     pub no_autoreload: bool,
@@ -80,6 +83,7 @@ impl Default for Serve {
             addresses: vec![],
             prefer_address_family: None,
             port: default::port(),
+            open: false,
             no_autoreload: false,
             headers: Default::default(),
             no_error_reporting: false,

--- a/src/config/rt/serve.rs
+++ b/src/config/rt/serve.rs
@@ -76,6 +76,7 @@ impl RtcServe {
             addresses,
             prefer_address_family,
             port,
+            open: _,
             // auto-reload is handle by the builder options
             no_autoreload: _,
             headers,


### PR DESCRIPTION
Fixes #847