### PR TITLE
feat: Initial support for cargo profiles

### DIFF
--- a/Trunk.toml
+++ b/Trunk.toml
@@ -8,6 +8,8 @@ trunk-version = "*"
 target = "index.html"
 # Build in release mode.
 release = false
+# Use a custom cargo profile
+# cargo_profile = ""
 # The output dir for all final assets.
 dist = "dist"
 # The public URL from which assets are to be served.
@@ -26,6 +28,8 @@ locked = false
 minify = "never" # can be one of: never, on_release, always
 # Allow disabling sub-resource integrity (SRI)
 no_sri = false
+# An optional cargo profile to use
+# cargo_profile = "release.trunk"
 
 [watch]
 # Paths to watch. The `build.target`'s parent folder is watched by default.

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -29,7 +29,7 @@ minify = "never" # can be one of: never, on_release, always
 # Allow disabling sub-resource integrity (SRI)
 no_sri = false
 # An optional cargo profile to use
-# cargo_profile = "release.trunk"
+# cargo_profile = "release-trunk"
 
 [watch]
 # Paths to watch. The `build.target`'s parent folder is watched by default.

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -8,7 +8,7 @@ trunk-version = "*"
 target = "index.html"
 # Build in release mode.
 release = false
-# Use a custom cargo profile
+# Use a custom cargo profile. Overrides the default chosen by cargo. Ignored if the 'index.html' has one configured.
 # cargo_profile = ""
 # The output dir for all final assets.
 dist = "dist"

--- a/guide/src/assets/index.md
+++ b/guide/src/assets/index.md
@@ -38,6 +38,9 @@ This will typically look like: `<link data-trunk rel="{type}" href="{path}" ..ot
 - `data-wasm-import-name`: (optional) the name of the global variable where the functions imported from WASM will be available (under the `window` object). Defaults to `wasmBindings` (which makes them available via `window.wasmBindings.<functionName>`).
 - `data-target-path`: (optional) Path where the output is placed inside the dist dir. If not present, the directory is placed in the dist root. The path must be a relative path without `..`.
 - `data-initializer`: (optional) Path to the (module) JavaScript file of the [initializer](../advanced/initializer.md).
+- `data-cargo-profile`: (optional) A cargo profile to use, instead of the default, for both release or dev mode.
+- `data-cargo-profile-release`: (optional) A cargo profile to use, instead of the default, for the release mode. Overrides the `data-cargo-profile` setting.
+- `data-cargo-profile-dev`: (optional) A cargo profile to use, instead of the default, for the dev mode. Overrides the `data-cargo-profile` setting.
 
 ### sass/scss
 

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -9,6 +9,7 @@
         "accept_invalid_certs": false,
         "all_features": false,
         "allow_self_closing_script": false,
+        "cargo_profile": null,
         "dist": "dist",
         "filehash": true,
         "frozen": false,
@@ -105,6 +106,14 @@
           "description": "Ignore error's related to self-closing script elements, and instead issue a warning.\n\nSince this issue can cause the HTML output to be truncated, only enable this in case you are sure it is caused due to a false positive.",
           "default": false,
           "type": "boolean"
+        },
+        "cargo_profile": {
+          "description": "Cargo profile to use. Conflicts with `release`.",
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "dist": {
           "description": "The output dir for all final assets",

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -108,7 +108,7 @@
           "type": "boolean"
         },
         "cargo_profile": {
-          "description": "Cargo profile to use. Conflicts with `release`.",
+          "description": "Cargo profile to use.\n\nOverrides the default chosen by cargo. Ignored if the 'index.html' has one configured.",
           "default": null,
           "type": [
             "string",

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -24,6 +24,10 @@ pub struct Build {
     #[arg(default_missing_value="true", num_args=0..=1)]
     pub release: Option<bool>,
 
+    /// Cargo profile to use for building.
+    #[arg(long, env = "TRUNK_BUILD_CARGO_PROFILE")]
+    pub cargo_profile: Option<String>,
+
     /// The output dir for all final assets
     #[arg(short, long, env = "TRUNK_BUILD_DIST")]
     pub dist: Option<PathBuf>,
@@ -122,6 +126,7 @@ impl Build {
             core,
             target,
             release,
+            cargo_profile,
             dist,
             offline,
             frozen,
@@ -142,6 +147,7 @@ impl Build {
 
         config.build.target = target.unwrap_or(config.build.target);
         config.build.release = release.unwrap_or(config.build.release);
+        config.build.cargo_profile = cargo_profile.or(config.build.cargo_profile);
         config.build.dist = dist.unwrap_or(config.build.dist);
         config.build.offline = offline.unwrap_or(config.build.offline);
         config.build.frozen = frozen.unwrap_or(config.build.frozen);

--- a/src/config/models/build.rs
+++ b/src/config/models/build.rs
@@ -23,7 +23,9 @@ pub struct Build {
     #[serde(default)]
     pub release: bool,
 
-    /// Cargo profile to use. Conflicts with `release`.
+    /// Cargo profile to use.
+    ///
+    /// Overrides the default chosen by cargo. Ignored if the 'index.html' has one configured.
     #[serde(default)]
     pub cargo_profile: Option<String>,
 

--- a/src/config/models/build.rs
+++ b/src/config/models/build.rs
@@ -23,6 +23,10 @@ pub struct Build {
     #[serde(default)]
     pub release: bool,
 
+    /// Cargo profile to use. Conflicts with `release`.
+    #[serde(default)]
+    pub cargo_profile: Option<String>,
+
     /// The output dir for all final assets
     #[serde(default = "default::dist")]
     pub dist: PathBuf,
@@ -184,6 +188,7 @@ impl Default for Build {
         Self {
             target: default::target(),
             release: false,
+            cargo_profile: None,
             dist: default::dist(),
             offline: false,
             frozen: false,

--- a/src/config/rt/build.rs
+++ b/src/config/rt/build.rs
@@ -32,6 +32,8 @@ pub struct RtcBuild {
     pub target_parent: PathBuf,
     /// Build in release mode.
     pub release: bool,
+    /// Cargo profile to use instead of the default selection.
+    pub cargo_profile: Option<String>,
     /// Build without network access
     pub offline: bool,
     /// Require Cargo.lock and cache are up to date
@@ -173,6 +175,7 @@ impl RtcBuild {
             target,
             target_parent,
             release: build.release,
+            cargo_profile: build.cargo_profile,
             public_url,
             filehash: build.filehash,
             staging_dist,
@@ -211,6 +214,7 @@ impl RtcBuild {
             target,
             target_parent,
             release: false,
+            cargo_profile: None,
             public_url: Default::default(),
             filehash: true,
             final_dist,

--- a/src/pipelines/rust/mod.rs
+++ b/src/pipelines/rust/mod.rs
@@ -198,13 +198,21 @@ impl RustApp {
 
         // cargo profile
 
-        let cargo_profile = match cfg.release {
+        let data_cargo_profile = match cfg.release {
             true => attrs.get("data-cargo-profile-dev"),
             false => attrs.get("data-cargo-profile-release"),
         }
-        .or_else(|| attrs.get("data-cargo-profile"))
-        .or_else(|| cfg.cargo_profile.as_ref())
-        .cloned();
+        .or_else(|| attrs.get("data-cargo-profile"));
+
+        let cargo_profile = match data_cargo_profile {
+            Some(cargo_profile) => {
+                if let Some(config_cargo_profile) = &cfg.cargo_profile {
+                    log::warn!("Cargo profile from configuration ({config_cargo_profile}) will be overridden with HTML file's more specific setting ({cargo_profile})");
+                }
+                Some(cargo_profile.clone())
+            }
+            None => cfg.cargo_profile.as_ref().cloned(),
+        };
 
         // cargo features
 

--- a/src/pipelines/rust/mod.rs
+++ b/src/pipelines/rust/mod.rs
@@ -199,8 +199,8 @@ impl RustApp {
         // cargo profile
 
         let data_cargo_profile = match cfg.release {
-            true => attrs.get("data-cargo-profile-dev"),
-            false => attrs.get("data-cargo-profile-release"),
+            true => attrs.get("data-cargo-profile-release"),
+            false => attrs.get("data-cargo-profile-dev"),
         }
         .or_else(|| attrs.get("data-cargo-profile"));
 


### PR DESCRIPTION
This isn't the complete "trunk profile" implementation, but maybe a short term solution in the right direction.

This allows setting a cargo profile on multiple levels. The idea is to allow influencing the cargo profile only. The trunk release flag still works as before. However you can now choose a `--cargo-profile` from the command line, from the Trunk.toml, from the `index.html` data attributes. In that order of preference.