### PR TITLE
OS-specific hook override 0.21.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3827,20 +3827,20 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
 dependencies = [
  "futures-util",
  "log",
  "native-tls",
  "rustls",
- "rustls-native-certs 0.7.3",
+ "rustls-native-certs 0.8.0",
  "rustls-pki-types",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
- "tungstenite 0.23.0",
+ "tungstenite 0.24.0",
 ]
 
 [[package]]
@@ -4086,7 +4086,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite 0.23.1",
+ "tokio-tungstenite 0.24.0",
  "toml 0.8.19",
  "tower-http",
  "tracing",
@@ -4122,9 +4122,9 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
 dependencies = [
  "byteorder",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ thiserror = "1"
 time = { version = "0.3", features = ["serde-well-known"] }
 tokio = { version = "1", default-features = false, features = ["full"] }
 tokio-stream = { version = "0.1", default-features = false, features = ["fs", "sync"] }
-tokio-tungstenite = "0.23"
+tokio-tungstenite = "0.24"
 toml = "0.8"
 tower-http = { version = "0.5.1", features = ["fs", "trace", "set-header"] }
 tracing = "0.1"

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -138,6 +138,14 @@ stage = "build"
 command = "sh"
 command_arguments = ["-c", "echo Staging directory: $TRUNK_STAGING_DIR"]
 
+[hooks.windows]
+# This shows how to create OS-specific overrides for hooks.
+# This will override the hook directly above it.
+# For overrides, only the `command` and `command_arguments` keys must be specified.
+# Valid values are `windows`, `macos`, and `linux`.
+command = "cmd"
+command_arguments = ["/c", "echo Staging directory: %TRUNK_STAGING_DIR%"]
+
 [[hooks]]
 # This hook example shows how command_arguments defaults to an empty list when absent. It also uses
 # the post_build stage, meaning it executes after the rest of the build is complete, just before

--- a/guide/src/build/hooks.md
+++ b/guide/src/build/hooks.md
@@ -44,3 +44,14 @@ the following environment variables are provided to the process:
 - `TRUNK_STAGING_DIR`: the full path of the Trunk staging directory.
 - `TRUNK_DIST_DIR`: the full path of the Trunk dist directory.
 - `TRUNK_PUBLIC_URL`: the configured public URL for Trunk.
+
+## OS-specific overrides
+
+Often times you will want to perform the same build step on different OSes, requiring different commands. 
+A typical example of this is using the `sh` command on Linux, but `cmd` on Windows. 
+To accomodate this, you can optionally create OS-specific overrides for each hook. 
+To do this, specify the default hook, then directly below it create a `[hooks.<os>]` entry where `<os>` 
+can be one of `windows`, `macos`, or `linux`. Within this entry you must specify only the `command` and 
+`command_argumnets` keys. You may provide multiple overrides for each hook. i.e. 
+One for `windows`, one for `macos`, and one for `linux`.
+

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -270,6 +270,26 @@
             "type": "string"
           }
         },
+        "linux": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/HookOverride"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "macos": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/HookOverride"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "stage": {
           "description": "The stage in the build process to execute this hook.",
           "allOf": [
@@ -277,6 +297,37 @@
               "$ref": "#/definitions/PipelineStage"
             }
           ]
+        },
+        "windows": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/HookOverride"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "HookOverride": {
+      "description": "OS-specific overrides.",
+      "type": "object",
+      "required": [
+        "command"
+      ],
+      "properties": {
+        "command": {
+          "description": "The command to run for this hook.",
+          "type": "string"
+        },
+        "command_arguments": {
+          "description": "Any arguments to pass to the command.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/site/content/assets.md
+++ b/site/content/assets.md
@@ -185,7 +185,13 @@ All hooks are executed using the same `stdin` and `stdout` as trunk. The executa
 
 ## OS-specific overrides
 
-Often times you will want to perform the same build step on different OSes, requiring different commands. A typical example of this is using the `sh` command on Linux, but `cmd` on Windows. To accomodate this, you can optionally create OS-specific overrides for each hook. To do this, specify the default hook, then directly below it create a `[hooks.<os>]` entry where `<os>` can be one of `windows`, `macos`, or `linux`. Within this entry you must specify only the `command` and `command_argumnets` keys. You may provide multiple overrides for each hook. i.e. One for `windows`, one for `macos`, and one for `linux`.
+Often times you will want to perform the same build step on different OSes, requiring different commands. 
+A typical example of this is using the `sh` command on Linux, but `cmd` on Windows. 
+To accomodate this, you can optionally create OS-specific overrides for each hook. 
+To do this, specify the default hook, then directly below it create a `[hooks.<os>]` entry where `<os>` 
+can be one of `windows`, `macos`, or `linux`. Within this entry you must specify only the `command` and 
+`command_argumnets` keys. You may provide multiple overrides for each hook. i.e. 
+One for `windows`, one for `macos`, and one for `linux`.
 
 # Auto-Reload
 

--- a/site/content/assets.md
+++ b/site/content/assets.md
@@ -183,6 +183,10 @@ All hooks are executed using the same `stdin` and `stdout` as trunk. The executa
   - `TRUNK_DIST_DIR`: the full path of the Trunk dist directory.
   - `TRUNK_PUBLIC_URL`: the configured public URL for Trunk.
 
+## OS-specific overrides
+
+Often times you will want to perform the same build step on different OSes, requiring different commands. A typical example of this is using the `sh` command on Linux, but `cmd` on Windows. To accomodate this, you can optionally create OS-specific overrides for each hook. To do this, specify the default hook, then directly below it create a `[hooks.<os>]` entry where `<os>` can be one of `windows`, `macos`, or `linux`. Within this entry you must specify only the `command` and `command_argumnets` keys. You may provide multiple overrides for each hook. i.e. One for `windows`, one for `macos`, and one for `linux`.
+
 # Auto-Reload
 
 As of `v0.14.0`, Trunk now ships with the ability to automatically reload your web app as the Trunk build pipeline completes.

--- a/src/config/models/hook.rs
+++ b/src/config/models/hook.rs
@@ -61,8 +61,11 @@ impl Hook {
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct HookOverrides {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub windows: Option<HookOverride>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub macos: Option<HookOverride>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub linux: Option<HookOverride>,
 }
 

--- a/src/config/models/hook.rs
+++ b/src/config/models/hook.rs
@@ -58,7 +58,7 @@ impl Hook {
 }
 
 /// Hook override config.
-#[derive(Clone, Debug, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct HookOverrides {
     pub windows: Option<HookOverride>,
@@ -67,7 +67,7 @@ pub struct HookOverrides {
 }
 
 /// OS-specific overrides.
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct HookOverride {
     /// The command to run for this hook.

--- a/src/config/models/hook.rs
+++ b/src/config/models/hook.rs
@@ -58,7 +58,7 @@ impl Hook {
 }
 
 /// Hook override config.
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct HookOverrides {
     pub windows: Option<HookOverride>,

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -14,10 +14,10 @@ pub fn spawn_hooks(cfg: Arc<RtcBuild>, stage: PipelineStage) -> HookHandles {
         .iter()
         .filter(|hook_cfg| hook_cfg.stage == stage)
         .map(|hook_cfg| {
-            let mut command = Command::new(&hook_cfg.command);
+            let mut command = Command::new(hook_cfg.command());
             command
                 .current_dir(&cfg.core.working_directory)
-                .args(&hook_cfg.command_arguments)
+                .args(hook_cfg.command_arguments())
                 .stdout(Stdio::inherit())
                 .stderr(Stdio::inherit())
                 .env("TRUNK_PROFILE", if cfg.release { "release" } else { "debug" })
@@ -27,9 +27,9 @@ pub fn spawn_hooks(cfg: Arc<RtcBuild>, stage: PipelineStage) -> HookHandles {
                 .env("TRUNK_DIST_DIR", &cfg.final_dist)
                 .env("TRUNK_PUBLIC_URL", &cfg.public_url);
 
-            tracing::info!(command_arguments = ?hook_cfg.command_arguments, "spawned hook {}", hook_cfg.command);
+            tracing::info!(command_arguments = ?hook_cfg.command_arguments(), "spawned hook {}", hook_cfg.command());
 
-            let command_name = hook_cfg.command.clone();
+            let command_name = hook_cfg.command().clone();
             tracing::info!(?stage, command = %command_name, "spawning hook");
             tokio::spawn(async move {
                 let status = command


### PR DESCRIPTION
Adds OS-specific overrides for hooks for version `0.21.x`.
Addresses Issue #792.