### PR TITLE
fix: replace host header by default

### DIFF
--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -420,7 +420,7 @@ fn router(state: Arc<State>, cfg: Arc<RtcServe>) -> Result<Router> {
         state.serve_base.as_str()
     );
 
-    let mut builder = ProxyBuilder::new(router);
+    let mut builder = ProxyBuilder::new(cfg.tls.is_some(), router);
 
     // Build proxies
 


### PR DESCRIPTION
This also aligns the behavior with the WS proxy behavior and adds header support for WS proxy requests too.

It also adds the XFP header.

Closes: https://github.com/trunk-rs/trunk/issues/879