### PR TITLE
fix: use the correct HTTP method (GET) for WS connections

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -315,7 +315,7 @@ impl ProxyHandlerWebSocket {
         let outbound_request = match make_outbound_request(
             inbound_proto,
             &outbound_uri,
-            http::Method::CONNECT,
+            http::Method::GET,
             req_headers,
             override_headers,
         ) {


### PR DESCRIPTION
Closes: https://github.com/trunk-rs/trunk/issues/883