### PR TITLE
Introducing Trunk Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![](https://img.shields.io/crates/d/trunk?label=downloads%20%28crates.io%29&style=flat-square)](https://crates.io/crates/trunk)
 [![](https://img.shields.io/github/downloads/trunk-rs/trunk/total?label=downloads%20%28GH%29&style=flat-square)](https://github.com/trunk-rs/trunk/releases)
 ![](https://img.shields.io/homebrew/installs/dy/trunk?color=brightgreen&label=downloads%20%28brew%29&style=flat-square)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Trunk%20Guru-006BFF?style=flat-square)](https://gurubase.io/g/trunk)
 
 **Build, bundle & ship your Rust WASM application to the web.**
 <br/>


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Trunk Guru](https://gurubase.io/g/trunk) to Gurubase. Trunk Guru uses the data from this repo and data from the [docs](https://trunkrs.dev) to answer questions by leveraging the LLM.

In this PR, I showcased the "Trunk Guru", which highlights that Trunk now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Trunk Guru in Gurubase, just let me know that's totally fine.
