### PR TITLE
Fix navigating away using links in Firefox is flaky

### DIFF
--- a/src/autoreload.js
+++ b/src/autoreload.js
@@ -90,7 +90,7 @@
                         break;
                 }
             };
-            ws.onclose = this.onclose;
+            ws.onclose = () => this.onclose();
         }
 
         onclose() {
@@ -102,7 +102,7 @@
                     // rebuilt on restart)
                     const ws = new WebSocket(this.url);
                     ws.onopen = () => window.location.reload();
-                    ws.onclose = this.onclose;
+                    ws.onclose = () => this.onclose();
                 },
                 this.poll_interval);
         }


### PR DESCRIPTION
As Firefox calls onclose when navigating away this led to the setTimeout running instantly because of a timeout of `undefined` which then led to a reload of the page which breaks navigating away.

For an explanation see https://stackoverflow.com/questions/43727516/how-adding-event-handler-inside-a-class-with-a-class-method-as-the-callback

Please release a new version with this fix.