### PR TITLE
feat: add CSP and enhance nonce generation

### DIFF
--- a/schemas/config.json
+++ b/schemas/config.json
@@ -10,6 +10,7 @@
         "all_features": false,
         "allow_self_closing_script": false,
         "cargo_profile": null,
+        "create_nonce": true,
         "dist": "dist",
         "filehash": true,
         "frozen": false,
@@ -18,6 +19,7 @@
         "minify": "never",
         "no_default_features": false,
         "no_sri": false,
+        "nonce_placeholder": "{{__TRUNK NONCE__}}",
         "offline": false,
         "public_url": "/",
         "public_url_no_trailing_slash_fix": false,
@@ -115,6 +117,11 @@
             "null"
           ]
         },
+        "create_nonce": {
+          "description": "Create 'nonce' attributes with a placeholder.",
+          "default": true,
+          "type": "boolean"
+        },
         "dist": {
           "description": "The output dir for all final assets",
           "default": "dist",
@@ -172,6 +179,11 @@
           "description": "Allows disabling sub-resource integrity (SRI)",
           "default": false,
           "type": "boolean"
+        },
+        "nonce_placeholder": {
+          "description": "The placeholder which is used in the 'nonce' attribute.",
+          "default": "{{__TRUNK NONCE__}}",
+          "type": "string"
         },
         "offline": {
           "description": "Run without accessing the network",

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -490,8 +490,24 @@
             "type": "string"
           }
         },
+        "csp": {
+          "description": "The CSP;  {{NONE}} is replaced by a random nonce",
+          "default": [
+            "script-src 'wasm-unsafe-eval' 'nonce-{{NONCE}}'",
+            "style-src 'nonce-{{NONCE}}'"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "disable_address_lookup": {
           "description": "Disable the reverse DNS lookup during startup",
+          "default": false,
+          "type": "boolean"
+        },
+        "disable_csp": {
+          "description": "Disable CSP header",
           "default": false,
           "type": "boolean"
         },

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -65,6 +65,10 @@ pub struct Serve {
     /// A base path to serve the application from [default: <public-url>]
     #[arg(long, env = "TRUNK_SERVE_SERVE_BASE")]
     pub serve_base: Option<String>,
+    /// Disable Content-Security-Policy [default: false]
+    #[arg(long)]
+    #[arg(default_missing_value="false", num_args=0..=1)]
+    pub disable_csp: Option<bool>,
 
     // NOTE: flattened structures come last
     #[command(flatten)]
@@ -134,6 +138,7 @@ impl Serve {
             tls_cert_path,
             serve_base,
             watch,
+            disable_csp,
         } = self;
 
         // apply overrides
@@ -158,6 +163,7 @@ impl Serve {
 
         config.serve.ws_protocol = ws_protocol.or(config.serve.ws_protocol);
         config.serve.ws_base = ws_base.or(config.serve.ws_base);
+        config.serve.disable_csp = disable_csp.unwrap_or(config.serve.disable_csp);
 
         if let Some(backend) = proxy_backend {
             // we have a single proxy from the command line

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -281,3 +281,14 @@ pub fn nonce() -> String {
     rand::rngs::OsRng.fill_bytes(&mut buffer);
     general_purpose::STANDARD.encode(buffer)
 }
+
+/// Creates the 'nonce' attribute.
+///
+/// Result is intented to be placed immediately without any spacing after the
+/// html tag or other attributes.
+pub fn nonce_attr(attr: &Option<String>) -> String {
+    match attr {
+        Some(v) => format!(r#" nonce="{v}""#),
+        None => "".to_string(),
+    }
+}

--- a/src/config/models/build.rs
+++ b/src/config/models/build.rs
@@ -141,6 +141,14 @@ pub struct Build {
     /// are sure it is caused due to a false positive.
     #[serde(default)]
     pub allow_self_closing_script: bool,
+
+    /// Create 'nonce' attributes with a placeholder.
+    #[serde(default = "default::create_nonce")]
+    pub create_nonce: bool,
+
+    /// The placeholder which is used in the 'nonce' attribute.
+    #[serde(default = "default::nonce_placeholder")]
+    pub nonce_placeholder: String,
 }
 
 fn string_or_vec<'de, T, D>(deserializer: D) -> Result<Vec<T>, D::Error>
@@ -210,6 +218,8 @@ impl Default for Build {
             minify: Default::default(),
             no_sri: false,
             allow_self_closing_script: false,
+            create_nonce: true,
+            nonce_placeholder: default::nonce_placeholder(),
         }
     }
 }
@@ -232,6 +242,14 @@ mod default {
 
     pub const fn inject_scripts() -> bool {
         true
+    }
+
+    pub const fn create_nonce() -> bool {
+        true
+    }
+
+    pub fn nonce_placeholder() -> String {
+        "{{__TRUNK NONCE__}}".to_string()
     }
 }
 

--- a/src/config/models/serve.rs
+++ b/src/config/models/serve.rs
@@ -82,6 +82,12 @@ pub struct Serve {
     #[serde(default)]
     #[deprecated]
     pub proxy_no_system_proxy: Option<bool>,
+    /// Disable CSP header
+    #[serde(default)]
+    pub disable_csp: bool,
+    /// The CSP;  {{NONE}} is replaced by a random nonce
+    #[serde(default = "default::csp")]
+    pub csp: Vec<String>,
 }
 
 impl Default for Serve {
@@ -110,6 +116,8 @@ impl Default for Serve {
             proxy_insecure: None,
             proxy_no_system_proxy: None,
             proxy_no_redirect: None,
+            disable_csp: false,
+            csp: default::csp(),
         }
     }
 }
@@ -117,6 +125,15 @@ impl Default for Serve {
 mod default {
     pub const fn port() -> u16 {
         8080
+    }
+
+    pub fn csp() -> Vec<String> {
+        [
+            "script-src 'wasm-unsafe-eval' 'nonce-{{NONCE}}'",
+            "style-src 'nonce-{{NONCE}}'",
+        ]
+        .map(|s| s.to_string())
+        .into()
     }
 }
 

--- a/src/config/rt/build.rs
+++ b/src/config/rt/build.rs
@@ -86,6 +86,8 @@ pub struct RtcBuild {
     pub no_sri: bool,
     /// Ignore error's due to self-closed script tags, instead will issue a warning.
     pub allow_self_closing_script: bool,
+    /// When set, create nonce attributes with the option as placeholder
+    pub create_nonce: Option<String>,
 }
 
 impl Deref for RtcBuild {
@@ -175,6 +177,8 @@ impl RtcBuild {
             public_url = public_url.fix_trailing_slash();
         }
 
+        let create_nonce = build.create_nonce.then_some(build.nonce_placeholder);
+
         Ok(Self {
             core,
             target,
@@ -203,6 +207,7 @@ impl RtcBuild {
             minify: build.minify,
             no_sri: build.no_sri,
             allow_self_closing_script: build.allow_self_closing_script,
+            create_nonce,
         })
     }
 
@@ -242,6 +247,7 @@ impl RtcBuild {
             minify: Minify::Never,
             no_sri: false,
             allow_self_closing_script: false,
+            create_nonce: None,
         })
     }
 

--- a/src/config/rt/serve.rs
+++ b/src/config/rt/serve.rs
@@ -48,6 +48,8 @@ pub struct RtcServe {
     pub tls: Option<TlsConfig>,
     /// A base path to serve the application from
     pub serve_base: Option<String>,
+    /// Disable Content-Security-Policy
+    pub csp: Option<Vec<String>>,
 }
 
 impl Deref for RtcServe {
@@ -100,6 +102,8 @@ impl RtcServe {
             proxy_insecure: _,
             proxy_no_system_proxy: _,
             proxy_no_redirect: _,
+            disable_csp,
+            csp,
         } = config.serve;
 
         let tls = tls_config(
@@ -122,6 +126,7 @@ impl RtcServe {
             ws_base,
             tls,
             serve_base,
+            csp: (!disable_csp).then_some(csp),
         })
     }
 

--- a/src/pipelines/html.rs
+++ b/src/pipelines/html.rs
@@ -1,7 +1,10 @@
 //! Source HTML pipelines.
 
 use crate::{
-    common::html_rewrite::{Document, DocumentOptions},
+    common::{
+        html_rewrite::{Document, DocumentOptions},
+        nonce_attr,
+    },
     config::{rt::RtcBuild, types::WsProtocol},
     hooks::{spawn_hooks, wait_hooks},
     pipelines::{
@@ -258,7 +261,8 @@ impl HtmlPipeline {
             target_html.append_html(
                 "body",
                 &format!(
-                    "<script>{}</script>",
+                    "<script{}>{}</script>",
+                    nonce_attr(&self.cfg.create_nonce),
                     RELOAD_SCRIPT.replace(
                         "{{__TRUNK_WS_PROTOCOL__}}",
                         &self.ws_protocol.map(|p| p.to_string()).unwrap_or_default()

--- a/src/pipelines/icon.rs
+++ b/src/pipelines/icon.rs
@@ -5,7 +5,7 @@ use super::{
     ATTR_HREF, ATTR_NO_MINIFY,
 };
 use crate::{
-    common::{html_rewrite::Document, target_path},
+    common::{html_rewrite::Document, nonce_attr, target_path},
     config::rt::RtcBuild,
     pipelines::{AssetFileType, ImageType},
     processing::integrity::{IntegrityType, OutputDigest},
@@ -131,10 +131,11 @@ impl IconOutput {
         dom.replace_with_html(
             &trunk_id_selector(self.id),
             &format!(
-                r#"<link rel="icon" href="{base}{file}"{attrs}/>"#,
+                r#"<link rel="icon" href="{base}{file}"{attrs}{nonce}/>"#,
                 base = &self.cfg.public_url,
                 file = self.file,
                 attrs = AttrWriter::new(&attrs, &[]),
+                nonce = nonce_attr(&self.cfg.create_nonce),
             ),
         )?;
         Ok(())

--- a/src/pipelines/inline.rs
+++ b/src/pipelines/inline.rs
@@ -2,7 +2,7 @@
 
 use super::{trunk_id_selector, AssetFile, Attrs, TrunkAssetPipelineOutput, ATTR_HREF, ATTR_TYPE};
 use crate::common::html_rewrite::Document;
-use crate::common::nonce;
+use crate::common::nonce_attr;
 use crate::config::rt::RtcBuild;
 use anyhow::{bail, Context, Result};
 use std::path::PathBuf;
@@ -136,15 +136,13 @@ pub struct InlineOutput {
 
 impl InlineOutput {
     pub async fn finalize(self, dom: &mut Document) -> Result<()> {
+        let nonce = nonce_attr(&self.cfg.create_nonce);
         let html = match self.content_type {
             ContentType::Html | ContentType::Svg => self.content,
-            ContentType::Css => format!(r#"<style nonce="{}">{}</style>"#, nonce(), self.content),
-            ContentType::Js => format!(r#"<script nonce="{}">{}</script>"#, nonce(), self.content),
-            ContentType::Module => format!(
-                r#"<script type="module" nonce="{}">{}</script>"#,
-                nonce(),
-                self.content
-            ),
+            ContentType::Css => format!(r#"<style{nonce}>{}</style>"#, self.content),
+            ContentType::Js => format!(r#"<script{nonce}>{}</script>"#, self.content),
+            #[rustfmt::skip]
+            ContentType::Module => format!(r#"<script type="module"{nonce}>{}</script>"#, self.content),
         };
 
         dom.replace_with_html(&trunk_id_selector(self.id), &html)

--- a/src/pipelines/js.rs
+++ b/src/pipelines/js.rs
@@ -5,7 +5,7 @@ use super::{
     ATTR_SRC,
 };
 use crate::{
-    common::{html_rewrite::Document, target_path},
+    common::{html_rewrite::Document, nonce_attr, target_path},
     config::rt::RtcBuild,
     pipelines::AssetFileType,
     processing::integrity::{IntegrityType, OutputDigest},
@@ -139,10 +139,11 @@ impl JsOutput {
         dom.replace_with_html(
             &super::trunk_script_id_selector(self.id),
             &format!(
-                r#"<script src="{base}{file}"{attrs}></script>"#,
+                r#"<script src="{base}{file}"{attrs}{nonce}></script>"#,
                 attrs = AttrWriter::new(&attrs, AttrWriter::EXCLUDE_SCRIPT),
                 base = &self.cfg.public_url,
-                file = self.file
+                file = self.file,
+                nonce = nonce_attr(&self.cfg.create_nonce),
             ),
         )
     }

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -106,7 +106,9 @@ impl TrunkAsset {
                         Self::Sass(Sass::new(cfg, html_dir, attrs, id).await?)
                     }
                     Icon::TYPE_ICON => Self::Icon(Icon::new(cfg, html_dir, attrs, id).await?),
-                    Inline::TYPE_INLINE => Self::Inline(Inline::new(html_dir, attrs, id).await?),
+                    Inline::TYPE_INLINE => {
+                        Self::Inline(Inline::new(cfg, html_dir, attrs, id).await?)
+                    }
                     Css::TYPE_CSS => Self::Css(Css::new(cfg, html_dir, attrs, id).await?),
                     CopyFile::TYPE_COPY_FILE => {
                         Self::CopyFile(CopyFile::new(cfg, html_dir, attrs, id).await?)

--- a/src/pipelines/rust/output.rs
+++ b/src/pipelines/rust/output.rs
@@ -84,10 +84,13 @@ impl RustAppOutput {
         if let Some(pattern) = pattern_preload {
             dom.append_html(head, &pattern_evaluate(pattern, &params))?;
         } else {
-            self.integrities
-                .clone()
-                .build()
-                .inject(dom, head, base, self.cross_origin)?;
+            self.integrities.clone().build().inject(
+                dom,
+                head,
+                base,
+                self.cross_origin,
+                &self.cfg.create_nonce,
+            )?;
         }
 
         let script = match pattern_script {

--- a/src/pipelines/rust/output.rs
+++ b/src/pipelines/rust/output.rs
@@ -1,6 +1,6 @@
 use super::super::trunk_id_selector;
 use crate::{
-    common::{html_rewrite::Document, nonce},
+    common::{html_rewrite::Document, nonce_attr},
     config::{rt::RtcBuild, types::CrossOrigin},
     pipelines::rust::{sri::SriBuilder, wasm_bindgen::WasmBindgenFeatures, RustAppType},
 };
@@ -128,7 +128,7 @@ window.{bindings} = bindings;
             false => ("", String::new()),
         };
 
-        let nonce = nonce();
+        let nonce = nonce_attr(&self.cfg.create_nonce);
 
         // the code to fire the `TrunkApplicationStarted` event
         let fire = r#"
@@ -140,7 +140,7 @@ dispatchEvent(new CustomEvent("TrunkApplicationStarted", {detail: {wasm}}));
         match &self.initializer {
             None => format!(
                 r#"
-<script type="module" nonce="{nonce}">
+<script type="module"{nonce}>
 import init{import} from '{base}{js}';
 const wasm = await init({init_arg});
 
@@ -155,7 +155,7 @@ const wasm = await init({init_arg});
             ),
             Some(initializer) => format!(
                 r#"
-<script type="module" nonce="{nonce}">
+<script type="module"{nonce}>
 {init}
 
 import init{import} from '{base}{js}';

--- a/src/pipelines/rust/sri.rs
+++ b/src/pipelines/rust/sri.rs
@@ -1,3 +1,4 @@
+use crate::common::nonce_attr;
 use crate::config::types::CrossOrigin;
 use crate::{
     common::html_rewrite::Document,
@@ -148,15 +149,17 @@ impl SriResult {
         head: &str,
         base: impl Display,
         cross_origin: CrossOrigin,
+        create_nonce: &Option<String>,
     ) -> anyhow::Result<()> {
+        let nonce = nonce_attr(create_nonce);
         for (SriKey { r#type, name }, SriEntry { digest, options }) in &self.integrities {
             let preload = if let Some(integrity) = digest.to_integrity_value() {
                 format!(
-                    r#"<link rel="{type}" href="{base}{name}" crossorigin={cross_origin} integrity="{integrity}"{options}>"#,
+                    r#"<link rel="{type}"{nonce} href="{base}{name}" crossorigin={cross_origin} integrity="{integrity}"{options}>"#,
                 )
             } else {
                 format!(
-                    r#"<link rel="{type}" href="{base}{name}" crossorigin={cross_origin}{options}>"#,
+                    r#"<link rel="{type}"{nonce} href="{base}{name}" crossorigin={cross_origin}{options}>"#,
                 )
             };
             location

--- a/src/pipelines/sass.rs
+++ b/src/pipelines/sass.rs
@@ -5,7 +5,7 @@ use super::{
     ATTR_INLINE, ATTR_NO_MINIFY,
 };
 use crate::{
-    common::{self, dist_relative, html_rewrite::Document, nonce, target_path},
+    common::{self, dist_relative, html_rewrite::Document, nonce_attr, target_path},
     config::rt::RtcBuild,
     processing::integrity::{IntegrityType, OutputDigest},
     tools::{self, Application},
@@ -206,11 +206,11 @@ pub enum CssRef {
 
 impl SassOutput {
     pub async fn finalize(self, dom: &mut Document) -> Result<()> {
+        let nonce = nonce_attr(&self.cfg.create_nonce);
         let html = match self.css_ref {
             // Insert the inlined CSS into a `<style>` tag.
             CssRef::Inline(css) => format!(
-                r#"<style {attrs} nonce="{}">{css}</style>"#,
-                nonce(),
+                r#"<style {attrs}{nonce}>{css}</style>"#,
                 attrs = AttrWriter::new(&self.attrs, AttrWriter::EXCLUDE_CSS_INLINE)
             ),
             // Link to the CSS file.

--- a/src/pipelines/sass.rs
+++ b/src/pipelines/sass.rs
@@ -219,7 +219,7 @@ impl SassOutput {
                 integrity.insert_into(&mut attrs);
 
                 format!(
-                    r#"<link rel="stylesheet" href="{base}{file}"{attrs}/>"#,
+                    r#"<link rel="stylesheet"{nonce} href="{base}{file}"{attrs}/>"#,
                     base = &self.cfg.public_url,
                     attrs = AttrWriter::new(&attrs, AttrWriter::EXCLUDE_CSS_LINK)
                 )

--- a/src/pipelines/tailwind_css.rs
+++ b/src/pipelines/tailwind_css.rs
@@ -5,7 +5,7 @@ use super::{
     ATTR_HREF, ATTR_INLINE, ATTR_NO_MINIFY,
 };
 use crate::{
-    common::{self, dist_relative, html_rewrite::Document, nonce, target_path},
+    common::{self, dist_relative, html_rewrite::Document, nonce_attr, target_path},
     config::rt::RtcBuild,
     processing::integrity::{IntegrityType, OutputDigest},
     tools::{self, Application},
@@ -184,11 +184,11 @@ pub enum CssRef {
 
 impl TailwindCssOutput {
     pub async fn finalize(self, dom: &mut Document) -> Result<()> {
+        let nonce = nonce_attr(&self.cfg.create_nonce);
         let html = match self.css_ref {
             // Insert the inlined CSS into a `<style>` tag.
             CssRef::Inline(css) => format!(
-                r#"<style {attrs} nonce="{}">{css}</style>"#,
-                nonce(),
+                r#"<style {attrs}{nonce}>{css}</style>"#,
                 attrs = AttrWriter::new(&self.attrs, AttrWriter::EXCLUDE_CSS_INLINE)
             ),
             // Link to the CSS file.

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -130,7 +130,7 @@ impl ServeSystem {
         let state = Arc::new(State::new(
             cfg.watch.build.final_dist.clone(),
             serve_base_url.to_string(),
-            &cfg,
+            cfg.clone(),
             ws_state,
         )?);
         let router = router(state, cfg.clone())?;
@@ -342,6 +342,8 @@ pub struct State {
     pub ws_base: String,
     /// Additional headers to add to responses.
     pub headers: HashMap<String, String>,
+    /// Configuration
+    pub cfg: Arc<RtcServe>,
 }
 
 impl State {
@@ -349,7 +351,7 @@ impl State {
     pub fn new(
         dist_dir: PathBuf,
         serve_base: String,
-        cfg: &RtcServe,
+        cfg: Arc<RtcServe>,
         ws_state: watch::Receiver<ws::State>,
     ) -> Result<Self> {
         let mut ws_base = cfg.ws_base()?.to_string();
@@ -363,6 +365,7 @@ impl State {
             ws_state,
             ws_base,
             headers: cfg.headers.clone(),
+            cfg,
         })
     }
 }


### PR DESCRIPTION
- adds `nonce="{{__TRUNK NONCE__}}"` placeholders to most/all generated links
- replaces `{{__TRUNK NONCE__}}` with a random nonce when serving a request
- adds `Content-Security-Policy` header with this random nonce
- adds configuration options to:
  - disable nonce generation
  - use a custom CSP
  - change used placeholder