### PR TITLE
HTML output filename

### DIFF
--- a/schemas/config.json
+++ b/schemas/config.json
@@ -13,6 +13,7 @@
         "dist": "dist",
         "filehash": true,
         "frozen": false,
+        "html_output": null,
         "inject_scripts": true,
         "locked": false,
         "minify": "never",
@@ -143,6 +144,13 @@
           "description": "Require Cargo.lock and cache are up to date",
           "default": false,
           "type": "boolean"
+        },
+        "html_output": {
+          "description": "The name of the output HTML file.\n\nIf not set, use the same file name as the target HTML file.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "inject_scripts": {
           "description": "Whether to inject scripts into your index file.\n\nThese values can only be provided via config file.",

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -146,7 +146,7 @@
           "type": "boolean"
         },
         "html_output": {
-          "description": "The name of the output HTML file.\n\nIf not set, use the same file name as the target HTML file.",
+          "description": "The name of the output HTML file.\n\nIf not set, use the same name as the target HTML file.",
           "type": [
             "string",
             "null"

--- a/site/content/configuration.md
+++ b/site/content/configuration.md
@@ -45,7 +45,7 @@ generation of the assets.
 ```toml
 [build]
 target = "index.html"       # The index HTML file to drive the bundling process.
-html_output = "index.html"  # The file name of the output HTML file.
+html_output = "index.html"  # The name of the output HTML file.
 release = false             # Build in release mode.
 dist = "dist"               # The output dir for all final assets.
 public_url = "/"            # The public URL from which assets are to be served.

--- a/site/content/configuration.md
+++ b/site/content/configuration.md
@@ -7,6 +7,7 @@ weight = 2
 Trunk supports a layered config system. At the base, a config file can encapsulate project specific defaults, paths, ports and other config. Environment variables can be used to overwrite config file values. Lastly, CLI arguments / options take final precedence.
 
 # Trunk.toml
+
 Trunk supports an optional `Trunk.toml` config file. An example config file is included [in the Trunk repo](https://github.com/trunk-rs/trunk/blob/main/Trunk.toml), and shows all available config options along with their default values. By default, Trunk will look for a `Trunk.toml` config file in the current working directory. Trunk supports the global `--config` option to specify an alternative location for the file.
 
 Note that any relative paths declared in a `Trunk.toml` file will be treated as being relative to the `Trunk.toml` file itself.
@@ -31,7 +32,6 @@ features early.
 **NOTE:** Versions prior do `0.19.0-alpha.2` currently do not support this
 check, and so they will silently ignore such an error for now.
 
-
 ```toml
 trunk-version = "^0.20.1"
 ```
@@ -44,17 +44,18 @@ generation of the assets.
 
 ```toml
 [build]
-target = "index.html" # The index HTML file to drive the bundling process.
-release = false       # Build in release mode.
-dist = "dist"         # The output dir for all final assets.
-public_url = "/"      # The public URL from which assets are to be served.
-filehash = true       # Whether to include hash values in the output file names.
-inject_scripts = true # Whether to inject scripts (and module preloads) into the finalized output.
-offline = false       # Run without network access
-frozen = false        # Require Cargo.lock and cache are up to date
-locked = false        # Require Cargo.lock is up to date
-minify = "never"      # Control minification: can be one of: never, on_release, always
-no_sri = false        # Allow disabling sub-resource integrity (SRI)
+target = "index.html"       # The index HTML file to drive the bundling process.
+html_output = "index.html"  # The file name of the output HTML file.
+release = false             # Build in release mode.
+dist = "dist"               # The output dir for all final assets.
+public_url = "/"            # The public URL from which assets are to be served.
+filehash = true             # Whether to include hash values in the output file names.
+inject_scripts = true       # Whether to inject scripts (and module preloads) into the finalized output.
+offline = false             # Run without network access
+frozen = false              # Require Cargo.lock and cache are up to date
+locked = false              # Require Cargo.lock is up to date
+minify = "never"            # Control minification: can be one of: never, on_release, always
+no_sri = false              # Allow disabling sub-resource integrity (SRI)
 ```
 
 ## Watch section
@@ -136,18 +137,22 @@ command_arguments = [] # Arguments to pass to command
 ```
 
 # Environment Variables
+
 Trunk environment variables mirror the `Trunk.toml` config schema. All Trunk environment variables have the following 3 part form `TRUNK_<SECTION>_<ITEM>`, where `TRUNK_` is the required prefix, `<SECTION>` is one of the `Trunk.toml` sections, and `<ITEM>` is a specific configuration item from the corresponding section. E.G., `TRUNK_SERVE_PORT=80` will cause `trunk serve` to listen on port `80`. The equivalent CLI invocation would be `trunk serve --port=80`.
 
 In addition, there is the variable `TRUNK_SKIP_VERSION_CHECK` which allows to control the update check (if that is)
 compiled into the version of trunk.
 
 # CLI Arguments & Options
+
 The final configuration layer is the CLI itself. Any arguments / options provided on the CLI will take final precedence over any other config layer.
 
 # Proxy
+
 Trunk ships with a built-in proxy which can be enabled when running `trunk serve`. There are two ways to configure the proxy, each discussed below. All Trunk proxies will transparently pass along the request body, headers, and query parameters to the proxy backend.
 
 ## Proxy CLI Flags
+
 The `trunk serve` command accepts two proxy related flags.
 
 `--proxy-backend` specifies the URL of the backend server to which requests should be proxied. The URI segment of the given URL will be used as the path on the Trunk server to handle proxy requests. E.G., `trunk serve --proxy-backend=http://localhost:9000/api/` will proxy any requests received on the path `/api/` to the server listening at `http://localhost:9000/api/`. Further path segments or query parameters will be seamlessly passed along.
@@ -159,4 +164,3 @@ The `trunk serve` command accepts two proxy related flags.
 `--proxy-no-sytem-proxy` bypasses the system proxy when contacting the proxy backend.
 
 `--proxy-ws` specifies that the proxy is for a WebSocket endpoint.
-

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -19,6 +19,10 @@ pub struct Build {
     /// The index HTML file to drive the bundling process
     pub target: Option<PathBuf>,
 
+    /// The name of the output HTML file.
+    #[arg(long, env = "TRUNK_BUILD_HTML_OUTPUT")]
+    pub html_output: Option<String>,
+
     /// Build in release mode
     #[arg(long, env = "TRUNK_BUILD_RELEASE")]
     #[arg(default_missing_value="true", num_args=0..=1)]
@@ -123,6 +127,7 @@ impl Build {
         let Self {
             core,
             target,
+            html_output,
             release,
             cargo_profile,
             dist,
@@ -144,6 +149,7 @@ impl Build {
         } = self;
 
         config.build.target = target.unwrap_or(config.build.target);
+        config.build.html_output = html_output.or(config.build.html_output);
         config.build.release = release.unwrap_or(config.build.release);
         config.build.cargo_profile = cargo_profile.or(config.build.cargo_profile);
         config.build.dist = dist.unwrap_or(config.build.dist);

--- a/src/config/models/build.rs
+++ b/src/config/models/build.rs
@@ -21,7 +21,7 @@ pub struct Build {
 
     /// The name of the output HTML file.
     ///
-    /// If not set, use the same file name as the target HTML file.
+    /// If not set, use the same name as the target HTML file.
     pub html_output: Option<String>,
 
     /// Build in release mode [default: false]

--- a/src/config/models/build.rs
+++ b/src/config/models/build.rs
@@ -19,6 +19,11 @@ pub struct Build {
     #[serde(default = "default::target")]
     pub target: PathBuf,
 
+    /// The name of the output HTML file.
+    ///
+    /// If not set, use the same file name as the target HTML file.
+    pub html_output: Option<String>,
+
     /// Build in release mode [default: false]
     #[serde(default)]
     pub release: bool,
@@ -189,6 +194,7 @@ impl Default for Build {
     fn default() -> Self {
         Self {
             target: default::target(),
+            html_output: None,
             release: false,
             cargo_profile: None,
             dist: default::dist(),

--- a/src/config/rt/build.rs
+++ b/src/config/rt/build.rs
@@ -31,6 +31,8 @@ pub struct RtcBuild {
     pub core: RtcCore,
     /// The index HTML file to drive the bundling process.
     pub target: PathBuf,
+    /// The file name of the output HTML file.
+    pub html_output_filename: String,
     /// The parent directory of the target index HTML file.
     pub target_parent: PathBuf,
     /// Build in release mode.
@@ -132,6 +134,15 @@ impl RtcBuild {
             )
         })?;
 
+        let html_output_filename = match build.html_output {
+            Some(html_output) => html_output,
+            None => target
+                .file_name()
+                .context("target path isn't a file path")?
+                .to_string_lossy()
+                .into_owned(),
+        };
+
         // Get the target HTML's parent dir, falling back to OS specific root, as that is the only
         // time when no parent could be determined.
         let target_parent = target
@@ -178,6 +189,7 @@ impl RtcBuild {
         Ok(Self {
             core,
             target,
+            html_output_filename,
             target_parent,
             release: build.release,
             cargo_profile: build.cargo_profile,
@@ -210,6 +222,7 @@ impl RtcBuild {
     #[cfg(test)]
     pub async fn new_test(tmpdir: &std::path::Path) -> anyhow::Result<Self> {
         let target = tmpdir.join("index.html");
+        let html_output_filename = String::from("index.html");
         let target_parent = tmpdir.to_path_buf();
         let final_dist = tmpdir.join("dist");
         let staging_dist = final_dist.join(".stage");
@@ -219,6 +232,7 @@ impl RtcBuild {
         Ok(Self {
             core: RtcCore::new_test(tmpdir),
             target,
+            html_output_filename,
             target_parent,
             release: false,
             cargo_profile: None,

--- a/src/config/rt/build.rs
+++ b/src/config/rt/build.rs
@@ -31,7 +31,7 @@ pub struct RtcBuild {
     pub core: RtcCore,
     /// The index HTML file to drive the bundling process.
     pub target: PathBuf,
-    /// The file name of the output HTML file.
+    /// The name of the output HTML file.
     pub html_output_filename: String,
     /// The parent directory of the target index HTML file.
     pub target_parent: PathBuf,

--- a/src/pipelines/html.rs
+++ b/src/pipelines/html.rs
@@ -183,9 +183,12 @@ impl HtmlPipeline {
             false => target_html.into_inner(),
         };
 
-        fs::write(self.cfg.staging_dist.join("index.html"), &output_html)
-            .await
-            .context("error writing finalized HTML output")?;
+        fs::write(
+            self.cfg.staging_dist.join(&self.cfg.html_output_filename),
+            &output_html,
+        )
+        .await
+        .context("error writing finalized HTML output")?;
 
         // Spawn and wait on post-build hooks.
         wait_hooks(spawn_hooks(self.cfg.clone(), PipelineStage::PostBuild)).await?;


### PR DESCRIPTION
Add `html_output` field to config to define the filename of the output HTML file.
When the field is not defined, it uses the same filename as the target HTML file.

