### PR TITLE
fix: autoreload: use correct context within onclose() handler

### DIFF
--- a/src/autoreload.js
+++ b/src/autoreload.js
@@ -90,7 +90,7 @@
                         break;
                 }
             };
-            ws.onclose = this.onclose;
+            ws.onclose = () => this.onclose();
         }
 
         onclose() {
@@ -102,7 +102,7 @@
                     // rebuilt on restart)
                     const ws = new WebSocket(this.url);
                     ws.onopen = () => window.location.reload();
-                    ws.onclose = this.onclose;
+                    ws.onclose = () => this.onclose();
                 },
                 this.poll_interval);
         }


### PR DESCRIPTION
Old code ran the `onclose()` handler in the context (`this`) of the websocket.  This is unwanted because the handler access attributes of the `Client` object.

Use arrow function to keep `this`.