### PR TITLE
fix: websocket: respond to Ping messages

### DIFF
--- a/src/ws.rs
+++ b/src/ws.rs
@@ -38,6 +38,10 @@ pub(crate) async fn handle_ws(mut ws: WebSocket, state: Arc<serve::State>) {
                         let _ = ws.close().await;
                         return
                     }
+                    Some(Ok(Message::Ping(msg))) => {
+                        tracing::trace!("responding to Ping");
+                        let _ = ws.send(Message::Pong(msg)).await;
+                    }
                     Some(Ok(msg)) => {
                         tracing::debug!("received message from browser: {msg:?} (ignoring)");
                     }


### PR DESCRIPTION
RFC6455 requires in section "5.5.2 Ping"

| Upon receipt of a Ping frame, an endpoint MUST send a Pong frame in | response

Not doing this causes e.g. Firefox to close the websocket automatically which triggers an (unwanted) reload of the page.