### PR TITLE
fix: disable nonce creation by default

### DIFF
--- a/Trunk.toml
+++ b/Trunk.toml
@@ -30,6 +30,8 @@ minify = "never" # can be one of: never, on_release, always
 no_sri = false
 # An optional cargo profile to use
 # cargo_profile = "release-trunk"
+# Allow injecting a nonce attribute
+create_nonce = false
 
 [watch]
 # Paths to watch. The `build.target`'s parent folder is watched by default.

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -10,7 +10,7 @@
         "all_features": false,
         "allow_self_closing_script": false,
         "cargo_profile": null,
-        "create_nonce": true,
+        "create_nonce": false,
         "dist": "dist",
         "filehash": true,
         "frozen": false,
@@ -120,7 +120,7 @@
         },
         "create_nonce": {
           "description": "Create 'nonce' attributes with a placeholder.",
-          "default": true,
+          "default": false,
           "type": "boolean"
         },
         "dist": {

--- a/src/config/models/build.rs
+++ b/src/config/models/build.rs
@@ -153,7 +153,7 @@ pub struct Build {
     pub allow_self_closing_script: bool,
 
     /// Create 'nonce' attributes with a placeholder.
-    #[serde(default = "default::create_nonce")]
+    #[serde(default)]
     pub create_nonce: bool,
 
     /// The placeholder which is used in the 'nonce' attribute.
@@ -230,7 +230,7 @@ impl Default for Build {
             minify: Default::default(),
             no_sri: false,
             allow_self_closing_script: false,
-            create_nonce: true,
+            create_nonce: false,
             nonce_placeholder: default::nonce_placeholder(),
         }
     }
@@ -253,10 +253,6 @@ mod default {
     }
 
     pub const fn inject_scripts() -> bool {
-        true
-    }
-
-    pub const fn create_nonce() -> bool {
         true
     }
 


### PR DESCRIPTION
As the nonce should be unique per request, it doesn't make sense to enable this by default, as that requires additional work on the serving side.

On the other side, having a (static) random value isn't correct either.

So we keep the current logic, but disable nonce generation by default, making it opt-in.

Closes #941