### PR TITLE
fix: do not unpack downloaded tailwindcss extra on macos or windows

### DIFF
--- a/src/tools.rs
+++ b/src/tools.rs
@@ -450,10 +450,9 @@ async fn install(app: Application, archive_file: File, target_directory: PathBuf
     tokio::task::spawn_blocking(move || {
         let mut archive = if app == Application::Sass && cfg!(target_os = "windows") {
             Archive::new_zip(archive_file)?
-        } else if app == Application::TailwindCss {
-            Archive::new_none(archive_file)
-        } else if app == Application::TailwindCssExtra
-            && (cfg!(target_os = "macos") || cfg!(target_os = "windows"))
+        } else if app == Application::TailwindCss
+            || (app == Application::TailwindCssExtra
+                && (cfg!(target_os = "macos") || cfg!(target_os = "windows")))
         {
             Archive::new_none(archive_file)
         } else {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -452,6 +452,10 @@ async fn install(app: Application, archive_file: File, target_directory: PathBuf
             Archive::new_zip(archive_file)?
         } else if app == Application::TailwindCss {
             Archive::new_none(archive_file)
+        } else if app == Application::TailwindCssExtra
+            && (cfg!(target_os = "macos") || cfg!(target_os = "windows"))
+        {
+            Archive::new_none(archive_file)
         } else {
             Archive::new_tar_gz(archive_file)
         };


### PR DESCRIPTION
Fix for this issue: https://github.com/trunk-rs/trunk/issues/953

On mac, tailwindcss-extra is downloaded, but the release is not a targz.

Tested on Mac.
Not tested on Windows,
the .exe file extension for release suggest, that it is not a targz too.

Using `(cfg!(target_os = "macos") || cfg!(target_os = "windows"))`
seems a little bit hacky, feel free to change or comment.