### PR TITLE
Align default behaviour of `html_output` config option with how it worked previously

### DIFF
--- a/schemas/config.json
+++ b/schemas/config.json
@@ -14,7 +14,7 @@
         "dist": "dist",
         "filehash": true,
         "frozen": false,
-        "html_output": null,
+        "html_output": "index.html",
         "inject_scripts": true,
         "locked": false,
         "minify": "never",
@@ -160,11 +160,9 @@
           "type": "boolean"
         },
         "html_output": {
-          "description": "The name of the output HTML file.\n\nIf not set, use the same name as the target HTML file.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "description": "The name of the output HTML file.\n\nIf not set, the file is named \"index.html\"",
+          "default": "index.html",
+          "type": "string"
         },
         "inject_scripts": {
           "description": "Whether to inject scripts into your index file.\n\nThese values can only be provided via config file.",

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -154,7 +154,7 @@ impl Build {
         } = self;
 
         config.build.target = target.unwrap_or(config.build.target);
-        config.build.html_output = html_output.or(config.build.html_output);
+        config.build.html_output = html_output.unwrap_or(config.build.html_output);
         config.build.release = release.unwrap_or(config.build.release);
         config.build.cargo_profile = cargo_profile.or(config.build.cargo_profile);
         config.build.dist = dist.unwrap_or(config.build.dist);

--- a/src/config/models/build.rs
+++ b/src/config/models/build.rs
@@ -21,8 +21,9 @@ pub struct Build {
 
     /// The name of the output HTML file.
     ///
-    /// If not set, use the same name as the target HTML file.
-    pub html_output: Option<String>,
+    /// If not set, the file is named "index.html"
+    #[serde(default = "default::html_output")]
+    pub html_output: String,
 
     /// Build in release mode [default: false]
     #[serde(default)]
@@ -207,7 +208,7 @@ impl Default for Build {
     fn default() -> Self {
         Self {
             target: default::target(),
-            html_output: None,
+            html_output: default::html_output(),
             release: false,
             cargo_profile: None,
             dist: default::dist(),
@@ -245,6 +246,10 @@ mod default {
     }
 
     pub fn target() -> PathBuf {
+        "index.html".into()
+    }
+
+    pub fn html_output() -> String {
         "index.html".into()
     }
 

--- a/src/config/rt/build.rs
+++ b/src/config/rt/build.rs
@@ -138,14 +138,7 @@ impl RtcBuild {
             )
         })?;
 
-        let html_output_filename = match build.html_output {
-            Some(html_output) => html_output,
-            None => target
-                .file_name()
-                .context("target path isn't a file path")?
-                .to_string_lossy()
-                .into_owned(),
-        };
+        let html_output_filename = build.html_output;
 
         // Get the target HTML's parent dir, falling back to OS specific root, as that is the only
         // time when no parent could be determined.


### PR DESCRIPTION
- Default to `index.html` as the filename if no config is specified