### PR TITLE
fix: dont escape asset integrity

### DIFF
--- a/src/pipelines/copy_dir.rs
+++ b/src/pipelines/copy_dir.rs
@@ -37,7 +37,7 @@ impl CopyDir {
             r#"required attr `href` missing for <link data-trunk rel="copy-dir" .../> element"#,
         )?;
         let mut path = PathBuf::new();
-        path.extend(href_attr.split('/'));
+        path.extend(href_attr.value.split('/'));
         if !path.is_absolute() {
             path = html_dir.join(path);
         }

--- a/src/pipelines/copy_file.rs
+++ b/src/pipelines/copy_file.rs
@@ -38,7 +38,7 @@ impl CopyFile {
             r#"required attr `href` missing for <link data-trunk rel="copy-file" .../> element"#,
         )?;
         let mut path = PathBuf::new();
-        path.extend(href_attr.split('/'));
+        path.extend(href_attr.value.split('/'));
         let asset = AssetFile::new(&html_dir, path).await?;
 
         let target_path = data_target_path(&attrs)?;

--- a/src/pipelines/css.rs
+++ b/src/pipelines/css.rs
@@ -47,7 +47,7 @@ impl Css {
             r#"required attr `href` missing for <link data-trunk rel="css" .../> element"#,
         )?;
         let mut path = PathBuf::new();
-        path.extend(href_attr.split('/'));
+        path.extend(href_attr.value.split('/'));
         let asset = AssetFile::new(&html_dir, path).await?;
 
         let integrity = IntegrityType::from_attrs(&attrs, &cfg)?;

--- a/src/pipelines/html.rs
+++ b/src/pipelines/html.rs
@@ -120,7 +120,7 @@ impl HtmlPipeline {
                 // raw data instead of passing around the link itself, is the lifetime
                 // requirements of elements used in `lol_html::html_content::HtmlRewriter`.
                 let attrs = el.attributes().iter().fold(Attrs::new(), |mut acc, attr| {
-                    acc.insert(attr.name(), attr.value());
+                    acc.insert(attr.name(), attr.value().into());
                     acc
                 });
 

--- a/src/pipelines/icon.rs
+++ b/src/pipelines/icon.rs
@@ -44,7 +44,7 @@ impl Icon {
             r#"required attr `href` missing for <link data-trunk rel="icon" .../> element"#,
         )?;
         let mut path = PathBuf::new();
-        path.extend(href_attr.split('/'));
+        path.extend(href_attr.value.split('/'));
         let asset = AssetFile::new(&html_dir, path).await?;
 
         let integrity = IntegrityType::from_attrs(&attrs, &cfg)?;

--- a/src/pipelines/inline.rs
+++ b/src/pipelines/inline.rs
@@ -37,11 +37,13 @@ impl Inline {
         )?;
 
         let mut path = PathBuf::new();
-        path.extend(href_attr.split('/'));
+        path.extend(href_attr.value.split('/'));
 
         let asset = AssetFile::new(&html_dir, path).await?;
-        let content_type =
-            ContentType::from_attr_or_ext(attrs.get(ATTR_TYPE), asset.ext.as_deref())?;
+        let content_type = ContentType::from_attr_or_ext(
+            attrs.get(ATTR_TYPE).map(|attr| &attr.value),
+            asset.ext.as_deref(),
+        )?;
 
         Ok(Self {
             id,

--- a/src/pipelines/js.rs
+++ b/src/pipelines/js.rs
@@ -47,11 +47,11 @@ impl Js {
             .get(ATTR_SRC)
             .context(r#"required attr `src` missing for <script data-trunk ...> element"#)?;
         let mut path = PathBuf::new();
-        path.extend(src_attr.split('/'));
+        path.extend(src_attr.value.split('/'));
         let asset = AssetFile::new(&html_dir, path).await?;
 
         let integrity = IntegrityType::from_attrs(&attrs, &cfg)?;
-        let module = attrs.get("type").map(|s| s.as_str()) == Some("module");
+        let module = attrs.get("type").map(|s| s.value.as_str()) == Some("module");
         let no_minify = attrs.contains_key(ATTR_NO_MINIFY);
         let target_path = data_target_path(&attrs)?;
 

--- a/src/pipelines/sass.rs
+++ b/src/pipelines/sass.rs
@@ -49,7 +49,7 @@ impl Sass {
             r#"required attr `href` missing for <link data-trunk rel="sass|scss" .../> element"#,
         )?;
         let mut path = PathBuf::new();
-        path.extend(href_attr.split('/'));
+        path.extend(href_attr.value.split('/'));
         let asset = AssetFile::new(&html_dir, path).await?;
         let use_inline = attrs.contains_key(ATTR_INLINE);
         let no_minify = attrs.contains_key(ATTR_NO_MINIFY);

--- a/src/pipelines/tailwind_css.rs
+++ b/src/pipelines/tailwind_css.rs
@@ -49,9 +49,9 @@ impl TailwindCss {
         let href_attr = attrs.get(ATTR_HREF).context(
             r#"required attr `href` missing for <link data-trunk rel="tailwind-css" .../> element"#,
         )?;
-        let tailwind_config = attrs.get(ATTR_CONFIG).cloned();
+        let tailwind_config = attrs.get(ATTR_CONFIG).map(|attr| &attr.value).cloned();
         let mut path = PathBuf::new();
-        path.extend(href_attr.split('/'));
+        path.extend(href_attr.value.split('/'));
         let asset = AssetFile::new(&html_dir, path).await?;
         let use_inline = attrs.contains_key(ATTR_INLINE);
 

--- a/src/pipelines/tailwind_css_extra.rs
+++ b/src/pipelines/tailwind_css_extra.rs
@@ -49,9 +49,9 @@ impl TailwindCssExtra {
         let href_attr = attrs.get(ATTR_HREF).context(
             r#"required attr `href` missing for <link data-trunk rel="tailwind-css-extra" .../> element"#,
         )?;
-        let tailwind_config = attrs.get(ATTR_CONFIG).cloned();
+        let tailwind_config = attrs.get(ATTR_CONFIG).map(|attr| &attr.value).cloned();
         let mut path = PathBuf::new();
-        path.extend(href_attr.split('/'));
+        path.extend(href_attr.value.split('/'));
         let asset = AssetFile::new(&html_dir, path).await?;
         let use_inline = attrs.contains_key(ATTR_INLINE);
 


### PR DESCRIPTION
Previously, we escape the integrity hash and therefore produce an invalid html as in https://github.com/trunk-rs/trunk/issues/765#issuecomment-2541635607. This PR introduce a `need_escape` to not escape the value if needed.

Please take a look at it thank you :D !

