### PR TITLE
Website: Fix index.html example and update generated output example

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -94,9 +94,12 @@ Trunk uses a source HTML file to drive all asset building and bundling. Trunk al
 <html>
   <head>
     <link data-trunk rel="scss" href="path/to/index.scss"/>
+    <link data-trunk rel="rust"/>
   </head>
 </html>
 ```
+
+The `index.scss` file may be empty but must exist.
 
 `trunk build` will produce the following HTML at `dist/index.html`, along with the compiled scss, WASM & the JS loader for the WASM:
 

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -106,17 +106,17 @@ The `index.scss` file may be empty but must exist.
 ```html
 <html>
   <head>
-    <link rel="stylesheet" href="/index-c920ca43256fdcb9.css">
-    <link rel="preload" href="/index-7eeee8fa37b7636a_bg.wasm" as="fetch" type="application/wasm" crossorigin="">
-    <link rel="modulepreload" href="/index-7eeee8fa37b7636a.js">
-  </head>
-  <body>
-    <script type="module">
-      import init, * as bindings from '/index-7eeee8fa37b7636a.js';
-      window.wasmBindings = bindings;
-      init('/index-7eeee8fa37b7636a_bg.wasm');
-    </script>
-  </body>
+    <link rel="stylesheet" href="/index-fe65950190f03c21.css" integrity="sha384-pgQCpTXf5Gd2g3bMQt/1fNJvznbtkReq/e3ooBAB1MPzHOTtbFDd5/tqXjQXrP4i"/>
+    
+<script type="module">
+import init, * as bindings from '/my_program_name-905e0077a27c1ab6.js';
+const wasm = await init('/my_program_name-905e0077a27c1ab6_bg.wasm');
+
+window.wasmBindings = bindings;
+dispatchEvent(new CustomEvent("TrunkApplicationStarted", {detail: {wasm}}));
+
+</script>
+  <link rel="modulepreload" href="/my_program_name-905e0077a27c1ab6.js" crossorigin="anonymous" integrity="sha384-XtIBch5nbGDblQX/VKgj2jEZMDa5+UbPgVtEQp18GY63sZAFYf81ithX9iMSLbBn"><link rel="preload" href="/my_program_name-905e0077a27c1ab6_bg.wasm" crossorigin="anonymous" integrity="sha384-Mf9hhCJLbxzecZm30W8m15djd1Z1yamaa52XBF0TsvX0/qITABYRpsB5cVmy3lt/" as="fetch" type="application/wasm"></head>
 </html>
 ```
 


### PR DESCRIPTION
Pull Request for https://github.com/trunk-rs/trunk/issues/958

* Added link tag to rust in the example html
* Added text that points out the `index.scss` must exist
* Updated the `dist/index.html` example with what actually was generated on my laptop. Unsure if that's a change that should be included or not - your call.

If needed, i can rebase the commit messages to include `fix:` to follow the conventional-commits guidelines, but I don't think these changes must be treated as a patch version increase by tooling.

