### PR TITLE
fix: dont unpack tailwindcss extra download for linux

### DIFF
--- a/src/tools.rs
+++ b/src/tools.rs
@@ -450,10 +450,7 @@ async fn install(app: Application, archive_file: File, target_directory: PathBuf
     tokio::task::spawn_blocking(move || {
         let mut archive = if app == Application::Sass && cfg!(target_os = "windows") {
             Archive::new_zip(archive_file)?
-        } else if app == Application::TailwindCss
-            || (app == Application::TailwindCssExtra
-                && (cfg!(target_os = "macos") || cfg!(target_os = "windows")))
-        {
+        } else if app == Application::TailwindCss || app == Application::TailwindCssExtra {
             Archive::new_none(archive_file)
         } else {
             Archive::new_tar_gz(archive_file)


### PR DESCRIPTION
When downloading tailwindcss-extra, the downloaded file is extracted on linux.
The downloaded file is a binary, must not been extracted.

Tested in this github action:
https://github.com/konnektoren/konnektoren-yew/actions/runs/14040373203/job/39308791401
