### PR TITLE
tools: bump default wasm-opt version to version_123

### DIFF
--- a/src/tools.rs
+++ b/src/tools.rs
@@ -108,7 +108,7 @@ impl Application {
             Self::TailwindCss => "3.3.5",
             Self::TailwindCssExtra => "1.7.25",
             Self::WasmBindgen => "0.2.89",
-            Self::WasmOpt => "version_116",
+            Self::WasmOpt => "version_123",
         }
     }
 


### PR DESCRIPTION
I think #904 can be closesd since from my testing new wasm_opt versions processe the binary successfully without any workarounds.

version_123 advertises a big speedup and it felt 5 times as fast when I compared it to version_122.