### PR TITLE
chore: Update Juice and tweak dark theme

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -4,7 +4,7 @@ title = "Trunk | Build, bundle & ship your Rust WASM application to the web"
 
 compile_sass = true
 build_search_index = true
-generate_feed = true
+generate_feeds = true
 
 theme = "juice"
 

--- a/site/sass/custom.scss
+++ b/site/sass/custom.scss
@@ -2,3 +2,8 @@
 .content pre > code {
   padding: unset;
 }
+
+// Fix the background color of the juice theme
+.content pre {
+    background-color: var(--code-background-color) !important;
+}

--- a/site/templates/index.html
+++ b/site/templates/index.html
@@ -53,6 +53,9 @@
     </style>
 {% endblock hero %}
 
+{% block sidebar %}
+{% endblock sidebar %}
+
 {% block footer %}
 <footer>
     <p>


### PR DESCRIPTION
I was looking at the site tonight and it blinded me with the lack of a dark theme lol 🙈

This PR adds support for a dark theme by:
- Updating the `juice` submodule to the latest version
- Renaming `generate_feed` to `generate_feeds` to get the Zola site building again
- Adding an override on the CSS for the codeblocks to fix a bad look with dark mode turned on
- Adding an empty `sideblock` section to remove the placeholder from the Juice theme

# Question
- Should I look into tweaking the code styling? It's readable, but not fantastic...

# Screenshot
## Homepage
![image](https://github.com/user-attachments/assets/3375385b-f0aa-4091-b829-3715876710f3)

## One of the sub-pages
![image](https://github.com/user-attachments/assets/d99092ce-1c13-4d90-90d4-79f82b726be8)
