### PR TITLE
keep .git when cleaning dist

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -166,7 +166,7 @@ impl BuildSystem {
             .context("error reading final dist dir")?;
         while let Some(entry) = entries.next().await {
             let entry = entry.context("error reading contents of final dist dir")?;
-            if entry.file_name() == STAGE_DIR {
+            if entry.file_name() == STAGE_DIR || entry.file_name() == ".git" {
                 continue;
             }
 


### PR DESCRIPTION
When cleaning the dist directory before moving build artifacts from the staging area, if a .git file exists, it should not be removed. This allows Trunk to build into a git worktree, for example.

This behavior also exists in Vite which was introduced in [this PR](https://github.com/vitejs/vite/pull/3043). Part of their justification is that a .git file could not be generated by Vite, but I'm not sure if this invariant holds for Trunk.