### PR TITLE
feat: bump wasm_opt to v123 to support aarch64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trunk"
-version = "0.21.13"
+version = "0.21.14"
 edition = "2021"
 description = "Build, bundle & ship your Rust WASM application to the web."
 license = "MIT/Apache-2.0"

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -78,7 +78,7 @@ sass = "1.69.5"
 # Default wasm-bindgen version to download.
 wasm_bindgen = "0.2.89"
 # Default wasm-opt version to download.
-wasm_opt = "version_116"
+wasm_opt = "version_123"
 # Default tailwindcss-cli version to download.
 tailwindcss = "3.3.5"
 


### PR DESCRIPTION
- starting with version_117 wasm_opt offers a better multi-arch support
- now possible to build on a non-x86 (docker) host like an arm64 MacOS
- making 123 default, fallback is possible by explicitly setting it in own Trunk.toml
- tested on arm64
- check: wasm_opt [116…117](https://github.com/WebAssembly/binaryen/compare/version_116...version_117), [117…118](https://github.com/WebAssembly/binaryen/compare/version_117...version_118), [118…119](https://github.com/WebAssembly/binaryen/compare/version_118...version_119), [119…120](https://github.com/WebAssembly/binaryen/compare/version_119...version_120), [120…121](https://github.com/WebAssembly/binaryen/compare/version_120...version_121), [121…122](https://github.com/WebAssembly/binaryen/compare/version_121...version_122), [122…123](https://github.com/WebAssembly/binaryen/compare/version_122...version_123)