### PR TITLE
chore: bump lockfile to current trunk version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4202,7 +4202,7 @@ dependencies = [
 
 [[package]]
 name = "trunk"
-version = "0.21.13"
+version = "0.21.14"
 dependencies = [
  "anyhow",
  "axum",


### PR DESCRIPTION
- version was set to 0.21.14 in Cargo.toml