### PR TITLE
feat: Add Gzip compress support for wasm binary

### DIFF
--- a/src/pipelines/rust/gzip.rs
+++ b/src/pipelines/rust/gzip.rs
@@ -1,0 +1,55 @@
+use std::{ops::Deref, str::FromStr};
+
+use anyhow::bail;
+use flate2::Compression;
+
+#[derive(PartialEq, Eq)]
+pub struct GzipLevel(Compression);
+
+impl GzipLevel {
+    pub const OFF: Self = Self(Compression::new(0));
+}
+
+impl FromStr for GzipLevel {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> anyhow::Result<Self, Self::Err> {
+        let level = match s {
+            "0" => Compression::new(0),
+            "1" => Compression::new(1),
+            "2" => Compression::new(2),
+            "3" => Compression::new(3),
+            "4" => Compression::new(4),
+            "5" => Compression::new(5),
+            "6" => Compression::new(6),
+            "7" => Compression::new(7),
+            "8" => Compression::new(8),
+            "9" => Compression::new(9),
+            "default" => Compression::default(),
+            "fast" => Compression::fast(),
+            "best" => Compression::best(),
+            _ => bail!("unknown gzip level `{}`", s),
+        };
+        Ok(Self(level))
+    }
+}
+
+impl AsRef<Compression> for GzipLevel {
+    fn as_ref(&self) -> &Compression {
+        &self.0
+    }
+}
+
+impl Deref for GzipLevel {
+    type Target = Compression;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Default for GzipLevel {
+    fn default() -> Self {
+        Self(Compression::default())
+    }
+}

--- a/src/pipelines/rust/output.rs
+++ b/src/pipelines/rust/output.rs
@@ -29,6 +29,8 @@ pub struct RustAppOutput {
     pub import_bindings: bool,
     /// The name of the WASM bindings import
     pub import_bindings_name: Option<String>,
+    /// Gzip compression enabled for the WASM file
+    pub gzip_compression_enabled: bool,
     /// The target of the initializer module
     pub initializer: Option<String>,
     /// The features supported by the version of wasm-bindgen used
@@ -141,8 +143,28 @@ dispatchEvent(new CustomEvent("TrunkApplicationStarted", {detail: {wasm}}));
         let init_with_object = self.wasm_bindgen_features.init_with_object;
 
         match &self.initializer {
-            None => format!(
-                r#"
+            None => {
+                if self.gzip_compression_enabled {
+                    format!(
+                        r#"
+<script type="module"{nonce}>
+import init{import} from '{base}{js}';
+const resp = await fetch('{base}{wasm}');
+if (!resp.ok) {{
+    throw new Error('Failed to fetch WASM module: ' + resp.statusText);
+}}
+
+const decompressStream = resp.body.pipeThrough(new DecompressionStream('gzip'));
+const wasmBytes = await new Response(decompressStream).arrayBuffer();
+const wasm = await init({{ module_or_path: wasmBytes }});
+
+{bind}
+{fire}
+</script>"#,
+                    )
+                } else {
+                    format!(
+                        r#"
 <script type="module"{nonce}>
 import init{import} from '{base}{js}';
 const wasm = await init({init_arg});
@@ -150,12 +172,14 @@ const wasm = await init({init_arg});
 {bind}
 {fire}
 </script>"#,
-                init_arg = if init_with_object {
-                    format!("{{ module_or_path: '{base}{wasm}' }}")
-                } else {
-                    format!("'{base}{wasm}'")
+                        init_arg = if init_with_object {
+                            format!("{{ module_or_path: '{base}{wasm}' }}")
+                        } else {
+                            format!("'{base}{wasm}'")
+                        }
+                    )
                 }
-            ),
+            }
             Some(initializer) => format!(
                 r#"
 <script type="module"{nonce}>


### PR DESCRIPTION
This is an attempt to add gzip compression support for wasm binary.

* Add data-gzip-compression attribute.
* Enable compression by default on release build, can be disabled by set `data-gzip-compression="0"`.
* Use DecompressionStream API to decompress at runtime.