### PR TITLE
Add Debug derive to ProxyClientOptions for better logging

### DIFF
--- a/src/serve/proxy.rs
+++ b/src/serve/proxy.rs
@@ -62,7 +62,7 @@ impl ProxyBuilder {
         } else {
             let no_sys_proxy = opts.no_system_proxy;
             let insecure = opts.insecure;
-            let client = self.clients.get_client(opts)?;
+            let client = self.clients.get_client(opts.clone())?;
             let handler = ProxyHandlerHttp::new(
                 proto,
                 client,
@@ -91,6 +91,7 @@ impl ProxyBuilder {
                     Default::default()
                 }
             );
+            tracing::debug!("Proxy options: {:?}", opts); // Optional debug log
             self.router = handler.register(self.router);
             Ok(self)
         }
@@ -101,7 +102,7 @@ impl ProxyBuilder {
     }
 }
 
-#[derive(Clone, Eq, PartialEq, Hash)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub(crate) struct ProxyClientOptions {
     pub insecure: bool,
     pub no_system_proxy: bool,


### PR DESCRIPTION
### Summary

This PR adds the `Debug` derive to the `ProxyClientOptions` struct in `proxy.rs`. This makes it easier to log and debug the struct during development and troubleshooting.

### Changes Made

- Added `#[derive(Debug)]` to `ProxyClientOptions` in `src/serve/proxy.rs`.

### Why?

Without `Debug`, logging or printing the struct during runtime results in a compile error. This change improves developer experience.

### Checklist

- [x] Code compiles
- [x] No breaking changes
- [x] Enhances developer tooling
