### PR TITLE
Use `glob` for `watch > ignore` paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,6 +384,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1351,6 +1361,19 @@ name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "globset"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
+dependencies = [
+ "aho-corasick 1.1.3",
+ "bstr",
+ "log",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
 
 [[package]]
 name = "h2"
@@ -4218,6 +4241,7 @@ dependencies = [
  "dunce",
  "flate2",
  "futures-util",
+ "globset",
  "hickory-resolver",
  "homedir",
  "htmlescape",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ directories = "6"
 dunce = "1"
 flate2 = "1"
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
+globset = "0.4.16"
 hickory-resolver = { version = "0.25.1", features = ["system-config"] }
 homedir = "0.3.3"
 htmlescape = "0.3.1"

--- a/examples/vanilla/Trunk.toml
+++ b/examples/vanilla/Trunk.toml
@@ -1,3 +1,9 @@
 [build]
 target = "index.html"
 dist = "dist"
+
+[watch]
+ignore = [
+	"ignoreme",
+	"**.ignore",
+]

--- a/src/cmd/watch.rs
+++ b/src/cmd/watch.rs
@@ -20,9 +20,9 @@ pub struct Watch {
     /// Watch specific file(s) or folder(s) [default: build target parent folder]
     #[arg(short, long, value_name = "path", env = "TRUNK_WATCH_WATCH")]
     pub watch: Option<Vec<PathBuf>>,
-    /// Paths to ignore [default: []]
+    /// Globs to ignore [default: []]
     #[arg(short, long, value_name = "path", env = "TRUNK_WATCH_IGNORE")]
-    pub ignore: Option<Vec<PathBuf>>,
+    pub ignore: Option<Vec<String>>,
     /// Using polling mode for detecting changes
     #[arg(long, env = "TRUNK_WATCH_POLL")]
     pub poll: bool,

--- a/src/config/models/watch.rs
+++ b/src/config/models/watch.rs
@@ -12,7 +12,7 @@ pub struct Watch {
 
     /// Paths to ignore [default: []]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub ignore: Vec<PathBuf>,
+    pub ignore: Vec<String>,
 }
 
 impl ConfigModel for Watch {}

--- a/src/config/rt/watch.rs
+++ b/src/config/rt/watch.rs
@@ -143,8 +143,21 @@ impl RtcWatch {
         let final_dist = globset::Glob::new(final_dist).map_err(|err| anyhow!(err))?;
         ignored_paths.add(final_dist).map_err(|err| anyhow!(err))?;
 
+        let final_dist_rec = build.final_dist.join("**");
+        let Some(final_dist_rec) = final_dist_rec.to_str() else {
+            return Err(anyhow!("could not convert final distribution path to glob"));
+        };
+        let final_dist_rec = globset::Glob::new(final_dist_rec).map_err(|err| anyhow!(err))?;
+        ignored_paths
+            .add(final_dist_rec)
+            .map_err(|err| anyhow!(err))?;
+
+        let working_dir = build
+            .working_directory
+            .canonicalize()
+            .map_err(|_| anyhow!("error taking the canonical path to the working directory"))?;
         for path in ignore {
-            let path = build.working_directory.join(path);
+            let path = working_dir.join(path);
             let Some(glob) = path.to_str() else {
                 return Err(anyhow!("could not convert {:?} to glob", path));
             };

--- a/src/pipelines/rust/mod.rs
+++ b/src/pipelines/rust/mod.rs
@@ -456,13 +456,17 @@ impl RustApp {
         // checking for errors, otherwise the dir will never be ignored. If we attempt to do
         // this pre-build, the canonicalization will fail and will not be ignored.
         if let Some(chan) = &mut self.ignore_chan {
-            let _ = chan.try_send(
-                self.manifest
-                    .metadata
-                    .target_directory
-                    .clone()
-                    .into_std_path_buf(),
-            );
+            let target_dir = self
+                .manifest
+                .metadata
+                .target_directory
+                .clone()
+                .into_std_path_buf()
+                .canonicalize()
+                .expect("valid path");
+            let target_dir_rec = target_dir.join("**");
+            let _ = chan.try_send(target_dir);
+            let _ = chan.try_send(target_dir_rec);
         }
 
         // Now propagate any errors which came from the cargo build.

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -107,7 +107,7 @@ impl WatchSystem {
     ) -> Result<Self> {
         // Create a channel for being able to listen for new paths to ignore while running.
         let (watch_tx, watch_rx) = mpsc::channel(1);
-        let (ignore_tx, ignore_rx) = mpsc::channel(1);
+        let (ignore_tx, ignore_rx) = mpsc::channel(2);
         let (build_tx, build_rx) = mpsc::channel(1);
 
         // Build the watcher.
@@ -333,9 +333,8 @@ impl WatchSystem {
         //     self.ignored_paths.push(path);
         // }
 
-        // TODO: How to handle errors here?
-        let path = arg_path.to_str().unwrap();
-        let path = globset::Glob::new(&path).unwrap();
+        let path = arg_path.to_str().expect("path as str");
+        let path = globset::Glob::new(&path).expect("valid glob");
         self.ignored_paths.add(path).unwrap();
     }
 }


### PR DESCRIPTION
Use `glob` pattern matching for [`watch > ignore` configuration](https://trunkrs.dev/configuration/#watch-section) when matching paths.

+ Creates breaking changes for how matching was previously performed by matching ancestors. Currently, the ignore path `ignore_me` matches `<working directory>/ignore_me` and all its descendants. With this change the ignore path `ignore_me` will only match `<working directory>/ignore_me`, but **not it's descendants**. To recursively ignore descendants one must add `ignore_me/**` as an ignore path.

+ Introduces dependency on [`globset`](https://crates.io/crates/globset).

+ Resolves #999.