### PR TITLE
Replace seahash with rapidhash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3030,6 +3030,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rapidhash"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ef3d82b018f786967b1a5d34a08ebc3c7a9ab35b5bcbe3e2e057a0a453f26c8"
+
+[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4262,12 +4268,12 @@ dependencies = [
  "openssl",
  "oxipng",
  "rand 0.9.0",
+ "rapidhash",
  "regex",
  "remove_dir_all",
  "reqwest",
  "rstest",
  "schemars",
- "seahash",
  "semver",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,11 @@ once_cell = "1"
 open = "5"
 oxipng = "9"
 rand = "0.9.0"
+rapidhash = { version = "3" }
 regex = "1"
 remove_dir_all = "1"
 reqwest = { version = "0.12", default-features = false, features = ["stream", "trust-dns"] }
 schemars = { version = "0.8", features = ["derive"] }
-seahash = { version = "4", features = ["use_std"] }
 semver = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -330,7 +330,7 @@ impl AssetFile {
             format!(
                 "{}-{:x}.{}",
                 &self.file_stem.to_string_lossy(),
-                seahash::hash(bytes.as_ref()),
+                rapidhash::v3::rapidhash_v3(bytes.as_ref()),
                 &self.ext.as_deref().unwrap_or_default()
             )
         } else {

--- a/src/pipelines/sass.rs
+++ b/src/pipelines/sass.rs
@@ -148,7 +148,7 @@ impl Sass {
         } else {
             // Hash the contents to generate a file name, and then write the contents to the dist
             // dir.
-            let hash = seahash::hash(css.as_bytes());
+            let hash = rapidhash::v3::rapidhash_v3(css.as_bytes());
 
             let file_name = if self.cfg.filehash {
                 format!("{}-{:x}.css", &self.asset.file_stem.to_string_lossy(), hash)

--- a/src/pipelines/tailwind_css.rs
+++ b/src/pipelines/tailwind_css.rs
@@ -129,7 +129,7 @@ impl TailwindCss {
         } else {
             // Hash the contents to generate a file name, and then write the contents to the dist
             // dir.
-            let hash = seahash::hash(css.as_bytes());
+            let hash = rapidhash::v3::rapidhash_v3(css.as_bytes());
             let file_name = if self.cfg.filehash {
                 format!("{}-{:x}.css", &self.asset.file_stem.to_string_lossy(), hash)
             } else {

--- a/src/pipelines/tailwind_css_extra.rs
+++ b/src/pipelines/tailwind_css_extra.rs
@@ -129,7 +129,7 @@ impl TailwindCssExtra {
         } else {
             // Hash the contents to generate a file name, and then write the contents to the dist
             // dir.
-            let hash = seahash::hash(css.as_bytes());
+            let hash = rapidhash::v3::rapidhash_v3(css.as_bytes());
             let file_name = if self.cfg.filehash {
                 format!("{}-{:x}.css", &self.asset.file_stem.to_string_lossy(), hash)
             } else {


### PR DESCRIPTION
Hi!

Maintainer of [rapidhash](https://github.com/hoxxep/rapidhash) here, and I saw that you were using seahash in trunk.

I believe rapidhash comprehensively beats seahash in quality and speed on all platforms, especially for long string/byte hashing. It's fully portable and doesn't rely on any hardware acceleration.

I couldn't find any benchmarks in the repo, but hopefully this improves project build times for users?

Very happy to answer any questions. Cheers!