### PR TITLE
Changes filehash to always be 16 characters

### DIFF
--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -328,7 +328,7 @@ impl AssetFile {
 
         let file_name = if with_hash {
             format!(
-                "{}-{:x}.{}",
+                "{}-{:0>16x}.{}",
                 &self.file_stem.to_string_lossy(),
                 seahash::hash(bytes.as_ref()),
                 &self.ext.as_deref().unwrap_or_default()

--- a/src/pipelines/sass.rs
+++ b/src/pipelines/sass.rs
@@ -151,7 +151,11 @@ impl Sass {
             let hash = seahash::hash(css.as_bytes());
 
             let file_name = if self.cfg.filehash {
-                format!("{}-{:x}.css", &self.asset.file_stem.to_string_lossy(), hash)
+                format!(
+                    "{}-{:0>16x}.css",
+                    &self.asset.file_stem.to_string_lossy(),
+                    hash
+                )
             } else {
                 temp_target_file_name
             };

--- a/src/pipelines/tailwind_css.rs
+++ b/src/pipelines/tailwind_css.rs
@@ -131,7 +131,11 @@ impl TailwindCss {
             // dir.
             let hash = seahash::hash(css.as_bytes());
             let file_name = if self.cfg.filehash {
-                format!("{}-{:x}.css", &self.asset.file_stem.to_string_lossy(), hash)
+                format!(
+                    "{}-{:0>16x}.css",
+                    &self.asset.file_stem.to_string_lossy(),
+                    hash
+                )
             } else {
                 file_name
             };

--- a/src/pipelines/tailwind_css_extra.rs
+++ b/src/pipelines/tailwind_css_extra.rs
@@ -131,7 +131,11 @@ impl TailwindCssExtra {
             // dir.
             let hash = seahash::hash(css.as_bytes());
             let file_name = if self.cfg.filehash {
-                format!("{}-{:x}.css", &self.asset.file_stem.to_string_lossy(), hash)
+                format!(
+                    "{}-{:0>16x}.css",
+                    &self.asset.file_stem.to_string_lossy(),
+                    hash
+                )
             } else {
                 file_name
             };


### PR DESCRIPTION
Filehash is a u64. Most of the time it is 16 characters, but if the leading digit is a 0, it becomes 15 characters. e.g. 0x0fffffffffffffff -> fffffffffffffff instead of 0fffffffffffffff. This changes it to format with leading zeros. Which makes writing code to extracting the hashes more predictable.